### PR TITLE
Use `save` instead of `export`

### DIFF
--- a/examples/PACKAGES/metatensor/create-lj-nickel.py
+++ b/examples/PACKAGES/metatensor/create-lj-nickel.py
@@ -12,7 +12,7 @@ model = metatensor_lj_test.lennard_jones_model(
     with_extension=False,
 )
 
-model.export("nickel-lj.pt")
+model.save("nickel-lj.pt")
 
 
 model = metatensor_lj_test.lennard_jones_model(
@@ -24,4 +24,4 @@ model = metatensor_lj_test.lennard_jones_model(
     energy_unit="eV",
     with_extension=True,
 )
-model.export("nickel-lj-extensions.pt", collect_extensions="collected-extensions/")
+model.save("nickel-lj-extensions.pt", collect_extensions="collected-extensions/")


### PR DESCRIPTION
Gets rid of the warning