### PR TITLE
Kokkos interface

### DIFF
--- a/cmake/Modules/Packages/KOKKOS.cmake
+++ b/cmake/Modules/Packages/KOKKOS.cmake
@@ -203,6 +203,10 @@ if(PKG_ML-IAP)
   endif()
 endif()
 
+if(PKG_ML-METATENSOR)
+  list(APPEND KOKKOS_PKG_SOURCES ${KOKKOS_PKG_SOURCES_DIR}/metatensor_system_kokkos.cpp)
+endif()
+
 if(PKG_PHONON)
   list(APPEND KOKKOS_PKG_SOURCES ${KOKKOS_PKG_SOURCES_DIR}/dynamical_matrix_kokkos.cpp)
   list(APPEND KOKKOS_PKG_SOURCES ${KOKKOS_PKG_SOURCES_DIR}/third_order_kokkos.cpp)

--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -1143,6 +1143,17 @@ https://pytorch.org/get-started/locally/.
          make yes-metatensor
          make <machine>
 
+   .. tab:: Metatensor and Kokkos
+
+      The metatensor-kokkos interface should be compiled as
+
+      .. code-block:: bash
+
+         cmake ../cmake/ -DPKG_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON -DPKG_ML-METATENSOR=ON -DCMAKE_PREFIX_PATH=/.../libtorch/share/cmake/
+         
+      where ``/.../libtorch/`` is the path to a libtorch C++11 ABI distribution (which can be downloaded from https://pytorch.org/get-started/locally/).
+      The OpenMP version (as opposed to the CUDA version) can be enabled with -DKokkos_ENABLE_OPENMP=ON instead of -DKokkos_ENABLE_CUDA=ON
+
 ----------
 
 .. _opt:

--- a/doc/src/pair_metatensor.rst
+++ b/doc/src/pair_metatensor.rst
@@ -3,6 +3,8 @@
 pair_style metatensor command
 =============================
 
+Accelerator Variants: *metatensor/kk*
+
 Syntax
 """"""
 

--- a/examples/PACKAGES/metatensor/in.kokkos.metatensor
+++ b/examples/PACKAGES/metatensor/in.kokkos.metatensor
@@ -1,0 +1,31 @@
+# Use the correct kokkos settings. `neigh half` does not imply the use of a half
+# neighbor list, only a change in how contributions are summed together.
+# cf https://github.com/lammps/lammps/pull/4412
+package kokkos newton on neigh half
+
+units metal
+boundary p p p
+
+atom_style atomic/kk
+lattice fcc 3.6
+region box block 0 2 0 2 0 2
+create_box 1 box
+create_atoms 1 box
+
+mass 1 58.693
+
+velocity all create 123 42
+
+pair_style metatensor/kk nickel-lj.pt
+pair_coeff * * 28
+
+timestep 0.001
+run_style verlet/kk
+fix 1 all npt temp 123 123 $(100 * dt) iso 0 0 $(1000 * dt) drag 1.0
+
+thermo 10
+thermo_style custom step temp pe etotal press vol
+
+# dump 1 all atom 10 dump.metatensor
+
+run 100

--- a/examples/PACKAGES/metatensor/readme.txt
+++ b/examples/PACKAGES/metatensor/readme.txt
@@ -1,0 +1,16 @@
+The base package can be compiled as cmake ../cmake -DPKG_ML-METATENSOR=ON
+-DCMAKE_PREFIX_PATH=/.../site-packages/torch/share/cmake/ where
+/.../site-packages/torch/ is the path to a pip installation of torch
+
+The kokkos version should be compiled as cmake ../cmake/ -DPKG_KOKKOS=ON
+-DKokkos_ENABLE_CUDA=ON -DPKG_ML-METATENSOR=ON
+-DCMAKE_PREFIX_PATH=/.../libtorch/share/cmake/ where /.../libtorch/ is the path
+to a libtorch C++11 ABI distribution (which can be downloaded from
+https://pytorch.org/get-started/locally/). The OpenMP version (as opposed to the
+CUDA version) can be enabled with -DKokkos_ENABLE_OPENMP=ON instead of
+-DKokkos_ENABLE_CUDA=ON
+
+The consistency between the two interfaces can be checked with
+../../../build/lmp -k on g 1 -in in.kokkos.metatensor (or `t Nt` instead of `g
+1` for an OpenMP run with Nt threads) and the output can be compared with that
+of the plain metatensor interface ../../../build/lmp -in in.metatensor

--- a/src/KOKKOS/metatensor_system_kokkos.cpp
+++ b/src/KOKKOS/metatensor_system_kokkos.cpp
@@ -1,0 +1,392 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Guillaume Fraux <guillaume.fraux@epfl.ch>
+                         Filippo Bigi <filippo.bigi@epfl.ch>
+------------------------------------------------------------------------- */
+#include "metatensor_system_kokkos.h"
+
+#include "metatensor_timer.h"
+
+#include "domain.h"
+#include "error.h"
+
+#include "atom_kokkos.h"
+
+#include <torch/cuda.h>
+
+using namespace LAMMPS_NS;
+
+template<typename T, class DeviceType>
+using UnmanagedView = Kokkos::View<T, Kokkos::LayoutRight, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+template<class DeviceType>
+MetatensorSystemAdaptorKokkos<DeviceType>::MetatensorSystemAdaptorKokkos(LAMMPS *lmp, MetatensorSystemOptions options):
+    MetatensorSystemAdaptor(lmp, options),
+    device_(KokkosDeviceToTorch<DeviceType>::convert())
+{
+    // MetatensorSystemAdaptor allocate on CPU, move to the right device
+    this->atomic_types_ = this->atomic_types_.to(this->device_);
+
+    auto tensor_options = torch::TensorOptions()
+        .dtype(torch::kFloat64)
+        .device(this->device_)
+        .requires_grad(true);
+
+    this->strain = torch::eye(3, tensor_options);
+}
+
+template<class DeviceType>
+void MetatensorSystemAdaptorKokkos<DeviceType>::setup_neighbors_remap_kk(metatensor_torch::System& system, NeighListKokkos<DeviceType>* list) {
+    auto _ = MetatensorTimer("converting kokkos neighbors with ghosts remapping");
+    auto dtype = system->positions().scalar_type();
+
+    auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
+
+    {
+        auto _ = MetatensorTimer("identifying ghosts and real atoms");
+        /*-------------- this will be done on CPU for now ------------------------*/
+        // The hashmap in the following code is not easy to implement in either Kokkos or torch
+        // The cost of this section seems to be very low anyway
+
+        // Collect the local atom id of all local & ghosts atoms, mapping ghosts
+        // atoms which are periodic images of local atoms back to the local atoms.
+        //
+        // Metatensor expects pairs corresponding to periodic atoms to be between
+        // the main atoms, but using the actual distance vector between the atom and
+        // the ghost.
+        original_atom_id_.clear();
+        original_atom_id_.reserve(total_n_atoms);
+
+        // identify all local atom by their LAMMPS atom tag.
+        local_atoms_tags_.clear();
+        for (int i=0; i<atom->nlocal; i++) {
+            original_atom_id_.emplace_back(i);
+            local_atoms_tags_.emplace(atom->tag[i], i);
+        }
+
+        // now loop over ghosts & map them back to the main cell if needed
+        ghost_atoms_tags_.clear();
+        for (int i=atom->nlocal; i<total_n_atoms; i++) {
+            auto tag = atom->tag[i];
+            auto it = local_atoms_tags_.find(tag);
+            if (it != local_atoms_tags_.end()) {
+                // this is the periodic image of an atom already owned by this domain
+                original_atom_id_.emplace_back(it->second);
+            } else {
+                // this can either be a periodic image of an atom owned by another
+                // domain, or directly an atom from another domain. Since we can not
+                // really distinguish between these, we take the first atom as the
+                // "main" one and remap all atoms with the same tag to the first one
+                auto it = ghost_atoms_tags_.find(tag);
+                if (it != ghost_atoms_tags_.end()) {
+                    // we already found this atom elsewhere in the system
+                    original_atom_id_.emplace_back(it->second);
+                } else {
+                    // this is the first time we are seeing this atom
+                    original_atom_id_.emplace_back(i);
+                    ghost_atoms_tags_.emplace(tag, i);
+                }
+            }
+        }
+    }
+    /*----------- end of "this will be done on CPU for now" --------------*/
+
+    auto original_id = torch::from_blob(
+        original_atom_id_.data(),
+        {total_n_atoms},
+        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
+    ).to(this->device_);
+
+    auto neighbors_kk = list->d_neighbors_transpose;
+    auto max_number_of_neighbors = list->maxneighs;
+
+    auto neighbors = torch::zeros(
+        {total_n_atoms, max_number_of_neighbors},
+        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    );
+    // mask neighbors_kk with NEIGHMASK. Torch doesn't have this functionality, we do it in Kokkos
+    auto neighbors_kk_masked = UnmanagedView<int32_t**, DeviceType>(
+        neighbors.template data_ptr<int32_t>(),
+        total_n_atoms,
+        max_number_of_neighbors
+    );
+    Kokkos::parallel_for(
+        Kokkos::MDRangePolicy({0, 0}, {total_n_atoms, max_number_of_neighbors}),
+        KOKKOS_LAMBDA(size_t i, size_t j) {
+            neighbors_kk_masked(i, j) = neighbors_kk(i, j) & NEIGHMASK;
+        }
+    );
+
+    // Convert NL-related data to torch tensors
+    auto numneigh = torch::from_blob(
+        list->d_numneigh.data(),
+        {total_n_atoms},
+        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    );
+    auto ilist = torch::from_blob(
+        list->d_ilist.data(),
+        {total_n_atoms},
+        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    );
+
+    auto x = system->positions().detach();
+    auto cell_inverse = system->cell().detach().inverse();
+
+    // convert from LAMMPS NL format to metatensor NL format
+    auto expanded_arange = torch::arange(
+        max_number_of_neighbors,
+        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    ).unsqueeze(0).expand({total_n_atoms, -1});
+    auto neighbor_2d_mask = expanded_arange < numneigh.unsqueeze(1);
+
+    auto expanded_arange_other_dim = torch::arange(
+        total_n_atoms,
+        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    ).unsqueeze(1).expand({-1, max_number_of_neighbors});
+    auto index_for_ilist = expanded_arange_other_dim.masked_select(neighbor_2d_mask);
+
+    auto centers_id = ilist.index_select(0, index_for_ilist);
+    auto neighbors_id = neighbors.masked_select(neighbor_2d_mask);
+
+    // change centers and neighbors to the original atom ids
+    auto centers_original_id = original_id.index_select(0, centers_id);
+    auto neighbors_original_id = original_id.index_select(0, neighbors_id);
+
+    // The following code is a direct translation of the code in the non-Kokkos
+    // version (MetaTensorSystemAdaptor::setup_neighbors_remap), but rewritten
+    // in torch to use the GPU
+    for (auto& cache: caches_) {
+        // current values of various tensors, these change depending on full/half setting
+        torch::Tensor centers_id_cur;
+        torch::Tensor neighbors_id_cur;
+        torch::Tensor centers_original_id_cur;
+        torch::Tensor neighbors_original_id_cur;
+
+        // filtered tensors, i.e. only containing pairs actually below the cutoff
+        torch::Tensor centers_original_id_filt_cur;
+        torch::Tensor neighbors_original_id_filt_cur;
+        torch::Tensor distances_filt_cur;
+        torch::Tensor cell_shifts_cur;
+
+        // other tensors that need to live across multiple timed sections
+        torch::Tensor samples_indices;
+        torch::Tensor samples_values;
+        {
+            auto _ = MetatensorTimer("filtering LAMMPS neighbor list");
+            // half list mask, if necessary
+            auto full_list = cache.options->full_list();
+
+            if (!full_list) {
+                centers_id_cur = centers_id;
+                neighbors_id_cur = neighbors_id;
+                centers_original_id_cur = centers_original_id;
+                neighbors_original_id_cur = neighbors_original_id;
+            } else {
+                auto half_list_mask = centers_original_id <= neighbors_original_id;
+                centers_id_cur = centers_id.masked_select(half_list_mask);
+                neighbors_id_cur = neighbors_id.masked_select(half_list_mask);
+                centers_original_id_cur = centers_original_id.masked_select(half_list_mask);
+                neighbors_original_id_cur = neighbors_original_id.masked_select(half_list_mask);
+            }
+
+            // distance mask
+            auto distances = x.index_select(0, neighbors_id_cur) - x.index_select(0, centers_id_cur);
+            auto cutoff_mask = torch::sum(distances.pow(2), 1) < cache.cutoff*cache.cutoff;
+
+            // index everything with the mask
+            auto centers_original_id_filt = centers_original_id_cur.masked_select(cutoff_mask);
+            auto neighbors_original_id_filt = neighbors_original_id_cur.masked_select(cutoff_mask);
+            auto distances_filt = distances.index({cutoff_mask, torch::indexing::Slice()});
+
+            // find filtered interatomic vectors using the original atoms
+            auto original_distances_filtered =
+                x.index_select(0, neighbors_original_id_filt)
+                - x.index_select(0, centers_original_id_filt);
+
+            // cell shifts
+            auto pair_shifts = distances_filt - original_distances_filtered;
+            auto cell_shifts = pair_shifts.matmul(cell_inverse);
+            cell_shifts = torch::round(cell_shifts).to(torch::kInt32);
+
+            if (full_list) {
+                centers_original_id_filt_cur = centers_original_id_filt;
+                neighbors_original_id_filt_cur = neighbors_original_id_filt;
+                distances_filt_cur = distances_filt;
+                cell_shifts_cur = cell_shifts;
+            } else {
+                auto half_list_cell_mask = centers_original_id_filt > neighbors_original_id_filt;
+                auto pair_with_image_mask = centers_original_id_filt == neighbors_original_id_filt;
+                auto negative_half_space_mask = torch::sum(cell_shifts, 1) < 0;
+                // reproduce this mask (from MetaTensorSystemAdaptor::setup_neighbors_remap) with torch:
+                // if ((shift[0] + shift[1] + shift[2] == 0) && (shift[2] < 0 || (shift[2] == 0 && shift[1] < 0)))
+                auto edge_mask = (
+                    (torch::sum(cell_shifts, 1) == 0) & (
+                        (cell_shifts.index({torch::indexing::Slice(), 2}) < 0) | (
+                            cell_shifts.index({torch::indexing::Slice(), 2}) == 0 &
+                            cell_shifts.index({torch::indexing::Slice(), 1}) < 0
+                        )
+                    )
+                );
+                auto final_mask = torch::logical_not(
+                    half_list_cell_mask | (
+                        pair_with_image_mask & (negative_half_space_mask | edge_mask)
+                    )
+                );
+                centers_original_id_filt_cur = centers_original_id_filt.masked_select(final_mask);
+                neighbors_original_id_filt_cur = neighbors_original_id_filt.masked_select(final_mask);
+                distances_filt_cur = distances_filt.index({final_mask, torch::indexing::Slice()});
+                cell_shifts_cur = cell_shifts.index({final_mask, torch::indexing::Slice()});
+            }
+
+            // make sure all the sample are unique
+            samples_values = torch::concatenate({
+                centers_original_id_filt_cur.unsqueeze(-1),
+                neighbors_original_id_filt_cur.unsqueeze(-1),
+                cell_shifts_cur
+            }, /*dim=*/1);
+
+            auto [samples_values_unique, samples_inverse, _counts] = torch::unique_dim(
+                samples_values, /*dim=*/0, /*sorted=*/true, /*return_inverse=*/true, /*return_counts=*/false
+            );
+            samples_values = samples_values_unique;
+
+            auto permutation = torch::arange(samples_inverse.size(0), samples_inverse.options());
+            samples_inverse = samples_inverse.flip({0});
+            permutation = permutation.flip({0});
+
+            samples_indices = torch::empty(samples_values.size(0), samples_inverse.options());
+            samples_indices.scatter_(0, samples_inverse, permutation);
+        }
+
+        // wrap into metatensor data structures
+        torch::intrusive_ptr<metatensor_torch::LabelsHolder> samples;
+        {
+            auto n_pairs = samples_values.size(0);
+            auto _ = MetatensorTimer("creating samples Labels (" +  std::to_string(n_pairs) + " pairs)");
+            samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+                std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
+                samples_values
+            );
+        }
+
+        torch::intrusive_ptr<metatensor_torch::TensorBlockHolder> neighbors;
+        {
+            auto _ = MetatensorTimer("creating neighbors TensorBlock");
+
+            neighbors = torch::make_intrusive<metatensor_torch::TensorBlockHolder>(
+                distances_filt_cur.index_select(0, samples_indices).unsqueeze(-1),
+                samples,
+                std::vector<metatensor_torch::TorchLabels>{
+                    metatensor_torch::LabelsHolder::create({"xyz"}, {{0}, {1}, {2}})->to(this->device_),
+                },
+                metatensor_torch::LabelsHolder::create({"distance"}, {{0}})->to(this->device_)
+            );
+        }
+
+        metatensor_torch::register_autograd_neighbors(system, neighbors, options_.check_consistency);
+        system->add_neighbor_list(cache.options, neighbors);
+    }
+}
+
+
+template<class DeviceType>
+metatensor_torch::System MetatensorSystemAdaptorKokkos<DeviceType>::system_from_lmp(
+    NeighList* list,
+    bool do_virial,
+    bool remap_pairs,
+    torch::ScalarType dtype,
+    torch::Device device
+) {
+    auto _ = MetatensorTimer("creating System from LAMMPS-kokkos data");
+    assert(device == this->device_);
+
+    auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
+
+    atomic_types_.resize_({total_n_atoms});
+    auto atomic_types_kk = UnmanagedView<int32_t*, DeviceType>(atomic_types_.data_ptr<int32_t>(), total_n_atoms);
+    auto type_mapping_kk = UnmanagedView<int32_t*, DeviceType>(options_.types_mapping, atomKK->ntypes + 1);
+    auto types_kk = atomKK->k_type.view<DeviceType>();
+    Kokkos::parallel_for(total_n_atoms, KOKKOS_LAMBDA(int i) {
+        atomic_types_kk(i) = type_mapping_kk(types_kk(i));
+    });
+
+    // atomKK->k_x contains "real" and then ghost atoms, in that order
+    auto k_x = atomKK->k_x.view<DeviceType>();
+    auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(this->device_);
+
+    this->positions = torch::from_blob(
+        k_x.data(), {total_n_atoms, 3},
+        // requires_grad=true since we always need gradients w.r.t. positions
+        tensor_options.requires_grad(true)
+    );
+
+    auto cell = torch::zeros({3, 3}, tensor_options);
+    cell[0][0] = domain->xprd;
+
+    cell[1][0] = domain->xy;
+    cell[1][1] = domain->yprd;
+
+    cell[2][0] = domain->xz;
+    cell[2][1] = domain->yz;
+    cell[2][2] = domain->zprd;
+
+    auto system_positions = this->positions.to(dtype);
+    cell = cell.to(dtype);
+
+    if (do_virial) {
+        auto model_strain = this->strain.to(dtype);
+
+        // pretend to scale positions/cell by the strain so that
+        // it enters the computational graph.
+        system_positions = system_positions.matmul(model_strain);
+        cell = cell.matmul(model_strain);
+    }
+
+    // Periodic boundary conditions handling.
+    // While Metatensor atomistic models can support mixed PBC settings, we
+    // currently assume that the system is fully periodic and we throw an error
+    // otherwise
+    if (!domain->xperiodic || !domain->yperiodic || !domain->zperiodic) {
+        error->all(FLERR, "metatensor/kk currently requires a fully periodic system");
+    }
+    auto pbc = torch::tensor(
+        {domain->xperiodic, domain->yperiodic, domain->zperiodic},
+        torch::TensorOptions().dtype(torch::kBool).device(this->device_)
+    );
+
+    auto system = torch::make_intrusive<metatensor_torch::SystemHolder>(
+        atomic_types_,
+        system_positions,
+        cell,
+        pbc
+    );
+
+    if (remap_pairs) {
+        auto* kk_list = dynamic_cast<NeighListKokkos<DeviceType>*>(list);
+        assert(kk_list != nullptr);
+        this->setup_neighbors_remap_kk(system, kk_list);
+    } else {
+        error->all(FLERR, "the kokkos version of metatensor requires remap_pairs to be true");
+    }
+
+    return system;
+}
+
+namespace LAMMPS_NS {
+template class MetatensorSystemAdaptorKokkos<LMPDeviceType>;
+#ifdef LMP_KOKKOS_GPU
+template class MetatensorSystemAdaptorKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/metatensor_system_kokkos.h
+++ b/src/KOKKOS/metatensor_system_kokkos.h
@@ -1,0 +1,98 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_METATENSOR_SYSTEM_KOKKOS_H
+#define LMP_METATENSOR_SYSTEM_KOKKOS_H
+
+#include "metatensor_system.h"
+#include "neigh_list_kokkos.h"
+
+namespace LAMMPS_NS {
+
+/* ---------------------------------------------------------------------- */
+
+// See https://kokkos.org/kokkos-core-wiki/API/core/execution_spaces.html for a
+// list of execution spaces.
+template<class DeviceType>
+struct KokkosDeviceToTorch {};
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+template<> struct KokkosDeviceToTorch<Kokkos::Serial> {
+    static torch::Device convert() {
+        return torch::Device(torch::kCPU);
+    }
+};
+#endif
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template<> struct KokkosDeviceToTorch<Kokkos::Cuda> {
+    static torch::Device convert() {
+        return torch::Device(torch::kCUDA, Kokkos::device_id());
+    }
+};
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+template<> struct KokkosDeviceToTorch<Kokkos::HIP> {
+    static torch::Device convert() {
+        return torch::Device(torch::kHIP, Kokkos::device_id());
+    }
+};
+#endif
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+template<> struct KokkosDeviceToTorch<Kokkos::OpenMP> {
+    static torch::Device convert() {
+        return torch::Device(torch::kCPU);
+    }
+};
+#endif
+
+#if defined(KOKKOS_ENABLE_THREADS)
+template<> struct KokkosDeviceToTorch<Kokkos::Threads> {
+    static torch::Device convert() {
+        return torch::Device(torch::kCPU);
+    }
+};
+#endif
+
+// Kokkos::SYCL, Kokkos::OpenMPTarget, Kokkos::HPX don't have a matching device
+// in torch.
+
+/* ---------------------------------------------------------------------- */
+
+template<class DeviceType>
+class MetatensorSystemAdaptorKokkos : public MetatensorSystemAdaptor {
+public:
+    MetatensorSystemAdaptorKokkos(LAMMPS *lmp, MetatensorSystemOptions options);
+    ~MetatensorSystemAdaptorKokkos() override {}
+
+    // Create a metatensor system matching the LAMMPS-Kokkos system data
+    metatensor_torch::System system_from_lmp(
+        NeighList* list,
+        bool do_virial,
+        bool remap_pairs,
+        torch::ScalarType dtype,
+        torch::Device device
+    ) override;
+
+    void setup_neighbors_remap_kk(metatensor_torch::System& system, NeighListKokkos<DeviceType>* list);
+
+private:
+    /// Torch device corresponding to the kokkos `DeviceType`
+    torch::Device device_;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif

--- a/src/KOKKOS/pair_metatensor_kokkos.cpp
+++ b/src/KOKKOS/pair_metatensor_kokkos.cpp
@@ -1,0 +1,283 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Guillaume Fraux <guillaume.fraux@epfl.ch>
+                         Filippo Bigi <filippo.bigi@epfl.ch>
+------------------------------------------------------------------------- */
+#include "pair_metatensor_kokkos.h"
+
+#include "error.h"
+#include "kokkos.h"
+#include "neigh_request.h"
+#include "atom_masks.h"
+
+#include "atom_kokkos.h"
+
+#include "metatensor_system_kokkos.h"
+#include "metatensor_types.h"
+#include "metatensor_timer.h"
+
+#include <algorithm>
+#include <cctype>
+
+using namespace LAMMPS_NS;
+
+// LAMMPS uses `LAMMPS_NS::tagint` and `int` for tags and neighbor lists, respectively.
+// For the moment, we require both to be int32_t for this interface
+static_assert(std::is_same_v<LAMMPS_NS::tagint, int32_t>, "Error: LAMMPS_NS::tagint must be int32_t to compile metatensor/kk");
+static_assert(std::is_same_v<int, int32_t>, "Error: int must be int32_t to compile metatensor/kk");
+
+template<typename T, class DeviceType>
+using UnmanagedView = Kokkos::View<T, Kokkos::LayoutRight, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+template<class DeviceType>
+PairMetatensorKokkos<DeviceType>::PairMetatensorKokkos(LAMMPS* lmp): PairMetatensor(lmp) {
+    // this will allow us to receive the NL in a GPU-friendly format
+    this->lmp->kokkos->neigh_transpose = 1;
+}
+
+template<class DeviceType>
+PairMetatensorKokkos<DeviceType>::~PairMetatensorKokkos() {}
+
+template<class DeviceType>
+void PairMetatensorKokkos<DeviceType>::init_style() {
+    PairMetatensor::init_style();
+
+    auto request = neighbor->find_request(this);
+    request->set_kokkos_host(
+        std::is_same_v<DeviceType, LMPHostType> &&
+        !std::is_same_v<DeviceType, LMPDeviceType>
+    );
+    request->set_kokkos_device(std::is_same_v<DeviceType, LMPDeviceType>);
+
+    // copy type mapping from host to device, to be able to give a device pointer
+    // to MetatensorSystemAdaptorKokkos
+    auto type_mapping_kk_host = UnmanagedView<int32_t*, LMPHostType>(this->type_mapping, atom->ntypes + 1);
+    this->type_mapping_kk = Kokkos::View<int32_t*, Kokkos::LayoutRight, DeviceType>("type_mapping_kk", atom->ntypes + 1);
+    Kokkos::deep_copy(this->type_mapping_kk, type_mapping_kk_host);
+
+    auto options = MetatensorSystemOptions{
+        this->type_mapping_kk.data(),
+        mts_data->max_cutoff,
+        mts_data->check_consistency,
+    };
+
+    // override the system adaptor with the kokkos version
+    this->system_adaptor = std::make_unique<MetatensorSystemAdaptorKokkos<DeviceType>>(lmp, options);
+
+    // request NL with the new adaptor
+    auto requested_nl = mts_data->model->run_method("requested_neighbor_lists");
+    for (const auto& ivalue: requested_nl.toList()) {
+        auto options = ivalue.get().toCustomClass<metatensor_torch::NeighborListOptionsHolder>();
+        auto cutoff = options->engine_cutoff(mts_data->evaluation_options->length_unit());
+        assert(cutoff <= mts_data->max_cutoff);
+
+        this->system_adaptor->add_nl_request(cutoff, options);
+    }
+}
+
+template<class DeviceType>
+void PairMetatensorKokkos<DeviceType>::pick_device(torch::Device* device, const char* requested) {
+    *device = KokkosDeviceToTorch<DeviceType>::convert();
+
+    if (requested != nullptr) {
+        auto requested_str = std::string(requested);
+        std::transform(requested_str.begin(), requested_str.end(), requested_str.begin(), ::tolower);
+        if (c10::DeviceTypeName(device->type(), /*lower_case=*/true) != requested_str) {
+            error->all(FLERR,
+                "requested device '{}' does not match the device being used by kokkos '{}', "
+                "use the non-kokkos version of this pair style to use a different "
+                "device for the model and LAMMPS",
+                requested, device->str()
+            );
+        }
+    }
+}
+
+template<class DeviceType>
+void PairMetatensorKokkos<DeviceType>::compute(int eflag, int vflag) {
+    if (std::getenv("LAMMPS_METATENSOR_PROFILE") != nullptr) {
+        MetatensorTimer::enable(true);
+    } else {
+        MetatensorTimer::enable(false);
+    }
+
+    auto _ = MetatensorTimer("PairMetatensorKokkos::compute");
+
+    /// Declare what we need to read from the atomKK object and what we will modify
+    this->atomKK->sync(ExecutionSpaceFromDevice<DeviceType>::space, X_MASK | F_MASK | TAG_MASK | TYPE_MASK | ENERGY_MASK | VIRIAL_MASK);
+    this->atomKK->modified(ExecutionSpaceFromDevice<DeviceType>::space, ENERGY_MASK | F_MASK | VIRIAL_MASK);
+
+    if (eflag || vflag) {
+        ev_setup(eflag, vflag);
+    } else {
+        evflag = vflag_fdotr = eflag_global = eflag_atom = 0;
+    }
+
+    if (eflag_atom) {
+        mts_data->evaluation_options->outputs.at("energy")->per_atom = true;
+    } else {
+        mts_data->evaluation_options->outputs.at("energy")->per_atom = false;
+    }
+
+    auto dtype = torch::kFloat64;
+    if (mts_data->capabilities->dtype() == "float64") {
+        dtype = torch::kFloat64;
+    } else if (mts_data->capabilities->dtype() == "float32") {
+        dtype = torch::kFloat32;
+    } else {
+        error->all(FLERR, "the model requested an unsupported dtype '{}'", mts_data->capabilities->dtype());
+    }
+
+    // transform from LAMMPS to metatensor System
+    auto system = this->system_adaptor->system_from_lmp(
+        mts_list,
+        static_cast<bool>(vflag_global),
+        mts_data->remap_pairs,
+        dtype,
+        this->mts_data->device
+    );
+
+    // only run the calculation for atoms actually in the current domain
+    mts_data->selected_atoms_values.resize_({atom->nlocal, 2});
+    mts_data->selected_atoms_values.index_put_({torch::indexing::Slice(), 0}, 0);
+    auto options = mts_data->selected_atoms_values.options();
+    mts_data->selected_atoms_values.index_put_(
+        {torch::indexing::Slice(), 1},
+        torch::arange(atom->nlocal, options)
+    );
+
+    auto selected_atoms = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+        std::vector<std::string>{"system", "atom"}, mts_data->selected_atoms_values
+    );
+    mts_data->evaluation_options->set_selected_atoms(selected_atoms);
+
+    torch::IValue result_ivalue;
+    try {
+        auto _ = MetatensorTimer("running Model::forward");
+        result_ivalue = mts_data->model->forward({
+            std::vector<metatensor_torch::System>{system},
+            mts_data->evaluation_options,
+            mts_data->check_consistency
+        });
+    } catch (const std::exception& e) {
+        error->all(FLERR, "error evaluating the torch model: {}", e.what());
+    }
+
+    auto result = result_ivalue.toGenericDict();
+    auto energy = result.at("energy").toCustomClass<metatensor_torch::TensorMapHolder>();
+    auto energy_block = metatensor_torch::TensorMapHolder::block_by_id(energy, 0);
+    auto energy_tensor = energy_block->values();
+
+    // compute forces/virial on device with backward propagation
+    {
+        // reset gradients to zero before calling backward
+        this->system_adaptor->positions.mutable_grad() = torch::Tensor();
+        this->system_adaptor->strain.mutable_grad() = torch::Tensor();
+
+        auto _ = MetatensorTimer("running Model::backward");
+        energy_tensor.backward(-torch::ones_like(energy_tensor));
+    }
+
+    {
+        auto _ = MetatensorTimer("storing model output in LAMMPS data structures");
+
+        // move results to cpu for storing
+        auto energy_detached = energy_tensor.detach().to(torch::kCPU).to(torch::kFloat64);
+        auto energy_samples = energy_block->samples();
+
+        // store the energy returned by the model
+        torch::Tensor global_energy;
+        if (eflag_atom) {
+            assert(energy_samples->size() == 2);
+            assert(energy_samples->names()[0] == "system");
+            assert(energy_samples->names()[1] == "atom");
+
+            auto samples_values = energy_samples->values().to(torch::kCPU);
+            auto samples = samples_values.accessor<int32_t, 2>();
+
+            int64_t n_atoms = atom->nlocal + atom->nghost;
+            assert(samples_values.sizes() == mts_data->selected_atoms_values.sizes());
+
+            auto energies = energy_detached.accessor<double, 2>();
+            for (int64_t i=0; i<energy_samples->count(); i++) {
+                assert(samples[i][0] == 0);
+                // handle potentially out of order samples in
+                // the per-atom energy tensor
+                auto atom_i = samples[i][1];
+                assert(atom_i < n_atoms);
+                eatom[atom_i] += energies[i][0];
+            }
+
+            global_energy = energy_detached.sum(0);
+            assert(energy_detached.sizes() == std::vector<int64_t>({1}));
+        } else {
+            assert(energy_samples->size() == 1);
+            assert(energy_samples->names()[0] == "system");
+
+            assert(energy_detached.sizes() == std::vector<int64_t>({1, 1}));
+            global_energy = energy_detached.reshape({1});
+        }
+
+        if (eflag_global) {
+            eng_vdwl += global_energy.item<double>();
+        }
+
+        // store forces/virial
+        auto forces_tensor = this->system_adaptor->positions.grad().contiguous();
+        assert(forces_tensor.scalar_type() == torch::kFloat64);
+
+        auto forces_lammps_kk = this->atomKK->k_f.template view<DeviceType>();
+        auto forces_metatensor_kk = UnmanagedView<double**, DeviceType>(
+            forces_tensor.template data_ptr<double>(),
+            forces_tensor.size(0), 3
+        );
+
+        Kokkos::parallel_for(
+            system->size(),
+            KOKKOS_LAMBDA(size_t i) {
+                forces_lammps_kk(i, 0) += forces_metatensor_kk(i, 0);
+                forces_lammps_kk(i, 1) += forces_metatensor_kk(i, 1);
+                forces_lammps_kk(i, 2) += forces_metatensor_kk(i, 2);
+            }
+        );
+
+        assert(!vflag_fdotr);
+
+        if (vflag_global) {
+            auto virial_tensor = this->system_adaptor->strain.grad().to(torch::kCPU);
+            assert(virial_tensor.is_cpu() && virial_tensor.scalar_type() == torch::kFloat64);
+            auto predicted_virial = virial_tensor.template accessor<double, 2>();
+
+            virial[0] += predicted_virial[0][0];
+            virial[1] += predicted_virial[1][1];
+            virial[2] += predicted_virial[2][2];
+
+            virial[3] += 0.5 * (predicted_virial[1][0] + predicted_virial[0][1]);
+            virial[4] += 0.5 * (predicted_virial[2][0] + predicted_virial[0][2]);
+            virial[5] += 0.5 * (predicted_virial[2][1] + predicted_virial[1][2]);
+        }
+
+        if (vflag_atom) {
+            error->all(FLERR, "per atom virial is not implemented");
+        }
+    }
+}
+
+namespace LAMMPS_NS {
+template class PairMetatensorKokkos<LMPDeviceType>;
+#ifdef LMP_KOKKOS_GPU
+template class PairMetatensorKokkos<LMPHostType>;
+#endif
+}

--- a/src/KOKKOS/pair_metatensor_kokkos.h
+++ b/src/KOKKOS/pair_metatensor_kokkos.h
@@ -1,0 +1,53 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+#ifdef PAIR_CLASS
+// clang-format off
+PairStyle(metatensor/kk, PairMetatensorKokkos<LMPDeviceType>);
+// clang-format on
+#else
+
+#ifndef LMP_PAIR_METATENSOR_KOKKOS_H
+#define LMP_PAIR_METATENSOR_KOKKOS_H
+
+#include "pair_kokkos.h"
+#include "pair_metatensor.h"
+
+namespace LAMMPS_NS {
+
+template<class DeviceType>
+class MetatensorSystemAdaptorKokkos;
+
+template<class DeviceType>
+struct PairMetatensorDataKokkos;
+
+/// I noticed that most other kokkos packages inherit from their non-kokkos
+/// counterparts. It doesn't look like a good idea to me because
+/// they end up overriding everything... Not doing it here for now.
+template<class DeviceType>
+class PairMetatensorKokkos : public PairMetatensor {
+public:
+    PairMetatensorKokkos(class LAMMPS *);
+    ~PairMetatensorKokkos();
+
+    void init_style() override;
+    void compute(int eflag, int vflag) override;
+private:
+    void pick_device(c10::Device* device, const char* requested) override;
+
+    Kokkos::View<int32_t*, Kokkos::LayoutRight, DeviceType> type_mapping_kk;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/ML-METATENSOR/metatensor_system.cpp
+++ b/src/ML-METATENSOR/metatensor_system.cpp
@@ -293,7 +293,7 @@ void MetatensorSystemAdaptor::setup_neighbors_remap(metatensor_torch::System& sy
 
         torch::intrusive_ptr<metatensor_torch::LabelsHolder> samples;
         {
-            auto _ = MetatensorTimer("creating samples Labels (" +  std::to_string(n_pairs) +" pairs)");
+            auto _ = MetatensorTimer("creating samples Labels (" +  std::to_string(n_pairs) + " pairs)");
             samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
                 std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
                 samples_values
@@ -349,7 +349,6 @@ void MetatensorSystemAdaptor::setup_neighbors_no_remap(metatensor_torch::System&
     auto device = system->positions().device();
 
     double** x = atom->x;
-    auto total_n_atoms = atom->nlocal + atom->nghost;
 
     for (auto& cache: caches_) {
         {

--- a/src/ML-METATENSOR/metatensor_system.h
+++ b/src/ML-METATENSOR/metatensor_system.h
@@ -28,8 +28,9 @@
 namespace LAMMPS_NS {
 
 struct MetatensorSystemOptions {
-    // Mapping from LAMMPS types to metatensor types
-    const int32_t* types_mapping;
+    // Mapping from LAMMPS types to metatensor types.
+    // If used with kokkos, this should be a device pointer
+    int32_t* types_mapping;
     // interaction range of the model, in LAMMPS units
     double interaction_range;
     // should we run extra checks on the neighbor lists?
@@ -79,12 +80,12 @@ class MetatensorSystemAdaptor : public Pointers {
 public:
     MetatensorSystemAdaptor(LAMMPS *lmp, MetatensorSystemOptions options);
 
-    ~MetatensorSystemAdaptor();
+    virtual ~MetatensorSystemAdaptor();
 
     void add_nl_request(double cutoff, metatensor_torch::NeighborListOptions request);
 
     // Create a metatensor system matching the LAMMPS system data
-    metatensor_torch::System system_from_lmp(
+    virtual metatensor_torch::System system_from_lmp(
         NeighList* list,
         bool do_virial,
         bool remap_pairs,
@@ -99,7 +100,7 @@ public:
     // conversion) to access its gradient
     torch::Tensor positions;
 
- private:
+ protected:
     // setup the metatensor neighbors list from the internal LAMMPS one,
     // remapping periodic ghosts to the corresponding local atom
     void setup_neighbors_remap(metatensor_torch::System& system, NeighList* list);

--- a/src/ML-METATENSOR/metatensor_types.cpp
+++ b/src/ML-METATENSOR/metatensor_types.cpp
@@ -1,0 +1,97 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Guillaume Fraux <guillaume.fraux@epfl.ch>
+------------------------------------------------------------------------- */
+#include "metatensor_types.h"
+
+#include "citeme.h"
+#include "comm.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+PairMetatensorData::PairMetatensorData(std::string length_unit, std::string energy_unit):
+    device(torch::kCPU),
+    check_consistency(false),
+    remap_pairs(true),
+    max_cutoff(-1)
+{
+    auto options = torch::TensorOptions().dtype(torch::kInt32);
+    this->selected_atoms_values = torch::zeros({0, 2}, options);
+
+    // Initialize evaluation_options
+    this->evaluation_options = torch::make_intrusive<metatensor_torch::ModelEvaluationOptionsHolder>();
+    this->evaluation_options->set_length_unit(std::move(length_unit));
+
+    auto output = torch::make_intrusive<metatensor_torch::ModelOutputHolder>();
+    output->explicit_gradients = {};
+    output->set_quantity("energy");
+    output->set_unit(std::move(energy_unit));
+    output->per_atom = false;
+
+    this->evaluation_options->outputs.insert("energy", output);
+}
+
+void PairMetatensorData::load_model(
+   LAMMPS* lmp,
+   const char* path,
+   const char* extensions_directory
+) {
+   // TODO: seach for the model & extensions inside `$LAMMPS_POTENTIALS`?
+
+   if (this->model != nullptr) {
+       lmp->error->all(FLERR, "torch model is already loaded");
+   }
+
+   torch::optional<std::string> extensions = torch::nullopt;
+   if (extensions_directory != nullptr) {
+       extensions = std::string(extensions_directory);
+   }
+
+   try {
+       this->model = std::make_unique<torch::jit::Module>(
+           metatensor_torch::load_atomistic_model(path, extensions)
+       );
+   } catch (const c10::Error& e) {
+       lmp->error->all(FLERR, "failed to load metatensor model at '{}': {}", path, e.what());
+   }
+
+   auto capabilities_ivalue = this->model->run_method("capabilities");
+   this->capabilities = capabilities_ivalue.toCustomClass<metatensor_torch::ModelCapabilitiesHolder>();
+
+   if (!this->capabilities->outputs().contains("energy")) {
+       lmp->error->all(FLERR, "the model at '{}' does not have an \"energy\" output, we can not use it in pair_style metatensor", path);
+   }
+
+   if (lmp->comm->me == 0) {
+       auto metadata_ivalue = this->model->run_method("metadata");
+       auto metadata = metadata_ivalue.toCustomClass<metatensor_torch::ModelMetadataHolder>();
+       auto to_print = metadata->print();
+
+       if (lmp->screen) {
+           fprintf(lmp->screen, "\n%s\n", to_print.c_str());
+       }
+       if (lmp->logfile) {
+           fprintf(lmp->logfile,"\n%s\n", to_print.c_str());
+       }
+
+       // add the model references to LAMMPS citation handling mechanism
+       for (const auto& it: metadata->references) {
+           for (const auto& ref: it.value()) {
+               lmp->citeme->add(ref + "\n");
+           }
+       }
+   }
+}

--- a/src/ML-METATENSOR/metatensor_types.h
+++ b/src/ML-METATENSOR/metatensor_types.h
@@ -1,0 +1,57 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/, Sandia National Laboratories
+   LAMMPS Development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "lammps.h"
+
+#include <string>
+
+#include <torch/torch.h>
+#include <metatensor/torch.hpp>
+#include <metatensor/torch/atomistic.hpp>
+
+
+
+#ifndef LMP_METATENSOR_TYPES_H
+#define LMP_METATENSOR_TYPES_H
+
+namespace LAMMPS_NS {
+
+struct PairMetatensorData {
+   PairMetatensorData(std::string length_unit, std::string energy_unit);
+
+   void load_model(LAMMPS* lmp, const char* path, const char* extensions_directory);
+
+   // torch model in metatensor format
+   std::unique_ptr<torch::jit::Module> model;
+   // device to use for the calculations
+   torch::Device device;
+   // model capabilities, declared by the model
+   metatensor_torch::ModelCapabilities capabilities;
+   // run-time evaluation options, decided by this class
+   metatensor_torch::ModelEvaluationOptions evaluation_options;
+   // should metatensor check the data LAMMPS send to the model
+   // and the data the model returns?
+   bool check_consistency;
+   // whether pairs should be remapped, removing pairs between ghosts if there
+   // is an equivalent pair involving at least one local atom.
+   bool remap_pairs;
+   // how far away the model needs to know about neighbors
+   double max_cutoff;
+
+   // allocation cache for the selected atoms
+   torch::Tensor selected_atoms_values;
+};
+
+}    // namespace LAMMPS_NS
+
+#endif

--- a/src/ML-METATENSOR/pair_metatensor.cpp
+++ b/src/ML-METATENSOR/pair_metatensor.cpp
@@ -15,6 +15,7 @@
    Contributing authors: Guillaume Fraux <guillaume.fraux@epfl.ch>
 ------------------------------------------------------------------------- */
 #include "pair_metatensor.h"
+#include "metatensor_types.h"
 
 #include "atom.h"
 #include "error.h"
@@ -22,7 +23,6 @@
 #include "memory.h"
 #include "neighbor.h"
 #include "update.h"
-#include "citeme.h"
 #include "comm.h"
 
 #include "neigh_list.h"
@@ -47,113 +47,11 @@
 
 using namespace LAMMPS_NS;
 
-struct LAMMPS_NS::PairMetatensorData {
-    PairMetatensorData(std::string length_unit, std::string energy_unit);
-
-    void load_model(LAMMPS* lmp, const char* path, const char* extensions_directory);
-
-    // torch model in metatensor format
-    std::unique_ptr<torch::jit::Module> model;
-    // device to use for the calculations
-    torch::Device device;
-    // model capabilities, declared by the model
-    metatensor_torch::ModelCapabilities capabilities;
-    // run-time evaluation options, decided by this class
-    metatensor_torch::ModelEvaluationOptions evaluation_options;
-    // should metatensor check the data LAMMPS send to the model
-    // and the data the model returns?
-    bool check_consistency;
-    // whether pairs should be remapped, removing pairs between ghosts if there
-    // is an equivalent pair involving at least one local atom.
-    bool remap_pairs;
-    // how far away the model needs to know about neighbors
-    double max_cutoff;
-
-    // allocation cache for the selected atoms
-    torch::Tensor selected_atoms_values;
-    // adaptor from LAMMPS system to metatensor's
-    std::unique_ptr<MetatensorSystemAdaptor> system_adaptor;
-};
-
-PairMetatensorData::PairMetatensorData(std::string length_unit, std::string energy_unit):
-    system_adaptor(nullptr),
-    device(torch::kCPU),
-    check_consistency(false),
-    remap_pairs(true),
-    max_cutoff(-1)
+PairMetatensor::PairMetatensor(LAMMPS *lmp):
+    Pair(lmp),
+    type_mapping(nullptr),
+    system_adaptor(nullptr)
 {
-    auto options = torch::TensorOptions().dtype(torch::kInt32);
-    this->selected_atoms_values = torch::zeros({0, 2}, options);
-
-    // Initialize evaluation_options
-    this->evaluation_options = torch::make_intrusive<metatensor_torch::ModelEvaluationOptionsHolder>();
-    this->evaluation_options->set_length_unit(std::move(length_unit));
-
-    auto output = torch::make_intrusive<metatensor_torch::ModelOutputHolder>();
-    output->explicit_gradients = {};
-    output->set_quantity("energy");
-    output->set_unit(std::move(energy_unit));
-    output->per_atom = false;
-
-    this->evaluation_options->outputs.insert("energy", output);
-}
-
-void PairMetatensorData::load_model(
-    LAMMPS* lmp,
-    const char* path,
-    const char* extensions_directory
-) {
-    // TODO: seach for the model & extensions inside `$LAMMPS_POTENTIALS`?
-
-    if (this->model != nullptr) {
-        lmp->error->all(FLERR, "torch model is already loaded");
-    }
-
-    torch::optional<std::string> extensions = torch::nullopt;
-    if (extensions_directory != nullptr) {
-        extensions = std::string(extensions_directory);
-    }
-
-    try {
-        this->model = std::make_unique<torch::jit::Module>(
-            metatensor_torch::load_atomistic_model(path, extensions)
-        );
-    } catch (const c10::Error& e) {
-        lmp->error->all(FLERR, "failed to load metatensor model at '{}': {}", path, e.what());
-    }
-
-    auto capabilities_ivalue = this->model->run_method("capabilities");
-    this->capabilities = capabilities_ivalue.toCustomClass<metatensor_torch::ModelCapabilitiesHolder>();
-
-    if (!this->capabilities->outputs().contains("energy")) {
-        lmp->error->all(FLERR, "the model at '{}' does not have an \"energy\" output, we can not use it in pair_style metatensor", path);
-    }
-
-    if (lmp->comm->me == 0) {
-        auto metadata_ivalue = this->model->run_method("metadata");
-        auto metadata = metadata_ivalue.toCustomClass<metatensor_torch::ModelMetadataHolder>();
-        auto to_print = metadata->print();
-
-        if (lmp->screen) {
-            fprintf(lmp->screen, "\n%s\n", to_print.c_str());
-        }
-        if (lmp->logfile) {
-            fprintf(lmp->logfile,"\n%s\n", to_print.c_str());
-        }
-
-        // add the model references to LAMMPS citation handling mechanism
-        for (const auto& it: metadata->references) {
-            for (const auto& ref: it.value()) {
-                lmp->citeme->add(ref + "\n");
-            }
-        }
-    }
-}
-
-
-/* ---------------------------------------------------------------------- */
-
-PairMetatensor::PairMetatensor(LAMMPS *lmp): Pair(lmp), type_mapping(nullptr) {
     std::string energy_unit;
     std::string length_unit;
     if (strcmp(update->unit_style, "real") == 0) {
@@ -246,90 +144,16 @@ void PairMetatensor::settings(int argc, char ** argv) {
         }
     }
 
+    // load the model and get it's capabilities (including supported devices)
     mts_data->load_model(this->lmp, model_path, extensions_directory);
 
     // Select the device to use based on the model's preference, the user choice
     // and what's available.
-    auto available_devices = std::vector<torch::Device>();
-    for (const auto& device: mts_data->capabilities->supported_devices) {
-        if (device == "cpu") {
-            available_devices.push_back(torch::kCPU);
-        } else if (device == "cuda") {
-            if (torch::cuda::is_available()) {
-                // Get a MPI communicator for all processes on the current node
-                MPI_Comm local;
-                MPI_Comm_split_type(world, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local);
-                // Get the rank of this MPI process on the current node
-                int local_rank;
-                MPI_Comm_rank(local, &local_rank);
+    this->pick_device(&mts_data->device, requested_device);
 
-                int size;
-                MPI_Comm_size(local, &size);
-                if (size < torch::cuda::device_count()) {
-                    if (comm->me == 0) {
-                        error->warning(FLERR,
-                            "found {} CUDA-capable GPUs, but only {} MPI processes on the current node; the remaining GPUs will not be used",
-                            torch::cuda::device_count(), size
-                        );
-                    }
-                }
-
-                // split GPUs between node-local processes using round-robin allocation
-                int gpu_to_use = local_rank % torch::cuda::device_count();
-                available_devices.push_back(torch::Device(torch::kCUDA, gpu_to_use));
-            }
-        } else if (device == "mps") {
-            #if TORCH_VERSION_MAJOR >= 2
-            if (torch::mps::is_available()) {
-                available_devices.push_back(torch::Device("mps"));
-            }
-            #endif
-        } else {
-            error->warning(FLERR,
-                "the model declared support for unknown device '{}', it will be ignored", device
-            );
-        }
-    }
-
-    if (available_devices.empty()) {
-        error->all(FLERR,
-            "failed to find a valid device for the model at '{}': "
-            "the model supports {}, none of these where available",
-            model_path, torch::str(mts_data->capabilities->supported_devices)
-        );
-    }
-
-    if (requested_device == nullptr) {
-        // no user request, pick the device the model prefers
-        mts_data->device = available_devices[0];
-    } else {
-        bool found_requested_device = false;
-        for (const auto& device: available_devices) {
-            if (device.is_cpu() && strcmp(requested_device, "cpu") == 0) {
-                mts_data->device = device;
-                found_requested_device = true;
-                break;
-            } else if (device.is_cuda() && strcmp(requested_device, "cuda") == 0) {
-                mts_data->device = device;
-                found_requested_device = true;
-                break;
-            } else if (device.is_mps() && strcmp(requested_device, "mps") == 0) {
-                mts_data->device = device;
-                found_requested_device = true;
-                break;
-            }
-        }
-
-        if (!found_requested_device) {
-            error->all(FLERR,
-                "failed to find requested device ({}): it is either "
-                "not supported by this model or not available on this machine",
-                requested_device
-            );
-        }
-    }
-
+    // move all data to the correct device
     mts_data->model->to(mts_data->device);
+    mts_data->selected_atoms_values = mts_data->selected_atoms_values.to(mts_data->device);
 
     auto message = "Running simulation on " + mts_data->device.str() + " device with " + mts_data->capabilities->dtype() + " data";
     if (screen) {
@@ -341,6 +165,100 @@ void PairMetatensor::settings(int argc, char ** argv) {
 
     if (!allocated) {
         allocate();
+    }
+}
+
+std::vector<torch::DeviceType> PairMetatensor::available_devices() {
+    auto devices = std::vector<torch::DeviceType>();
+    for (const auto& supported: this->mts_data->capabilities->supported_devices) {
+        if (supported == "cpu") {
+            devices.push_back(torch::kCPU);
+        } else if (supported == "cuda" && torch::cuda::is_available()) {
+            devices.push_back(torch::kCUDA);
+        } else if (supported == "mps") {
+            #if TORCH_VERSION_MAJOR >= 2
+            if (torch::mps::is_available()) {
+                devices.push_back(torch::kMPS);
+            }
+            #endif
+        } else {
+            error->warning(FLERR,
+                "the model declared support for unknown device '{}', it will be ignored", supported
+            );
+        }
+    }
+
+    if (devices.empty()) {
+        error->all(FLERR,
+            "failed to find a valid device for this model: "
+            "the model supports {}, none of these where available",
+            torch::str(this->mts_data->capabilities->supported_devices)
+        );
+    }
+
+    return devices;
+}
+
+void PairMetatensor::pick_device(torch::Device* device, const char* requested) {
+    auto available_devices = this->available_devices();
+
+    auto picked_device_type = torch::kCPU;
+    if (requested == nullptr) {
+        // no user request, pick the device the model prefers
+        picked_device_type = available_devices[0];
+    } else {
+        bool found_requested_device = false;
+        for (const auto& device_type: available_devices) {
+            if (device_type == torch::kCPU && strcmp(requested, "cpu") == 0) {
+                picked_device_type = device_type;
+                found_requested_device = true;
+                break;
+            } else if (device_type == torch::kCUDA && strcmp(requested, "cuda") == 0) {
+                picked_device_type = device_type;
+                found_requested_device = true;
+                break;
+            } else if (device_type == torch::kMPS && strcmp(requested, "mps") == 0) {
+                picked_device_type = device_type;
+                found_requested_device = true;
+                break;
+            }
+        }
+
+        if (!found_requested_device) {
+            error->all(FLERR,
+                "failed to find requested device ({}): it is either "
+                "not supported by this model or not available on this machine",
+                requested
+            );
+        }
+    }
+
+    if (picked_device_type == torch::kCUDA) {
+        // distribute GPUs between multiple MPI processes on the same node
+
+        // (1) get a MPI communicator for all processes on the current node
+        MPI_Comm local;
+        MPI_Comm_split_type(world, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local);
+        // (2) get the rank of this MPI process on the current node
+        int local_rank;
+        MPI_Comm_rank(local, &local_rank);
+
+        int size;
+        MPI_Comm_size(local, &size);
+        if (size < torch::cuda::device_count()) {
+            if (comm->me == 0) {
+                error->warning(FLERR,
+                    "found {} CUDA-capable GPUs, but only {} MPI processes on the current node; the remaining GPUs will not be used",
+                    torch::cuda::device_count(), size
+                );
+            }
+        }
+
+        // (3) split GPUs between node-local processes using round-robin allocation
+        int gpu_to_use = local_rank % torch::cuda::device_count();
+        *device = torch::Device(picked_device_type, gpu_to_use);
+    } else {
+        *device = torch::Device(picked_device_type);
     }
 }
 
@@ -463,7 +381,7 @@ void PairMetatensor::init_style() {
         mts_data->max_cutoff,
         mts_data->check_consistency,
     };
-    mts_data->system_adaptor = std::make_unique<MetatensorSystemAdaptor>(lmp, options);
+    this->system_adaptor = std::make_unique<MetatensorSystemAdaptor>(lmp, options);
 
     // We ask LAMMPS for a full neighbor lists because we need to know about
     // ALL pairs, even if options->full_list() is false. We will then filter
@@ -479,7 +397,7 @@ void PairMetatensor::init_style() {
         auto cutoff = options->engine_cutoff(mts_data->evaluation_options->length_unit());
         assert(cutoff <= mts_data->max_cutoff);
 
-        mts_data->system_adaptor->add_nl_request(cutoff, options);
+        this->system_adaptor->add_nl_request(cutoff, options);
     }
 }
 
@@ -520,7 +438,7 @@ void PairMetatensor::compute(int eflag, int vflag) {
     }
 
     // transform from LAMMPS to metatensor System
-    auto system = mts_data->system_adaptor->system_from_lmp(
+    auto system = this->system_adaptor->system_from_lmp(
         mts_list,
         static_cast<bool>(vflag_global),
         mts_data->remap_pairs,
@@ -530,14 +448,17 @@ void PairMetatensor::compute(int eflag, int vflag) {
 
     // only run the calculation for atoms actually in the current domain
     mts_data->selected_atoms_values.resize_({atom->nlocal, 2});
-    for (int i=0; i<atom->nlocal; i++) {
-        mts_data->selected_atoms_values[i][0] = 0;
-        mts_data->selected_atoms_values[i][1] = i;
-    }
+    mts_data->selected_atoms_values.index_put_({torch::indexing::Slice(), 0}, 0);
+    auto options = mts_data->selected_atoms_values.options();
+    mts_data->selected_atoms_values.index_put_(
+        {torch::indexing::Slice(), 1},
+        torch::arange(atom->nlocal, options)
+    );
+
     auto selected_atoms = torch::make_intrusive<metatensor_torch::LabelsHolder>(
         std::vector<std::string>{"system", "atom"}, mts_data->selected_atoms_values
     );
-    mts_data->evaluation_options->set_selected_atoms(selected_atoms->to(mts_data->device));
+    mts_data->evaluation_options->set_selected_atoms(selected_atoms);
 
     torch::IValue result_ivalue;
     try {
@@ -556,20 +477,18 @@ void PairMetatensor::compute(int eflag, int vflag) {
     auto energy_block = metatensor_torch::TensorMapHolder::block_by_id(energy, 0);
     auto energy_tensor = energy_block->values();
 
-    // reset gradients to zero before calling backward
-    mts_data->system_adaptor->positions.mutable_grad() = torch::Tensor();
-    mts_data->system_adaptor->strain.mutable_grad() = torch::Tensor();
-
     // compute forces/virial on device with backward propagation
     {
+        // reset gradients to zero before calling backward
+        this->system_adaptor->positions.mutable_grad() = torch::Tensor();
+        this->system_adaptor->strain.mutable_grad() = torch::Tensor();
+
         auto _ = MetatensorTimer("running Model::backward");
         energy_tensor.backward(-torch::ones_like(energy_tensor));
     }
 
     {
         auto _ = MetatensorTimer("storing model output in LAMMPS data structures");
-
-        auto forces_tensor = mts_data->system_adaptor->positions.grad();
 
         // move results to cpu for storing
         auto energy_detached = energy_tensor.detach().to(torch::kCPU).to(torch::kFloat64);
@@ -613,6 +532,7 @@ void PairMetatensor::compute(int eflag, int vflag) {
         }
 
         // store forces/virial
+        auto forces_tensor = this->system_adaptor->positions.grad();
         assert(forces_tensor.is_cpu() && forces_tensor.scalar_type() == torch::kFloat64);
 
         auto forces = forces_tensor.accessor<double, 2>();
@@ -625,7 +545,7 @@ void PairMetatensor::compute(int eflag, int vflag) {
         assert(!vflag_fdotr);
 
         if (vflag_global) {
-            auto virial_tensor = mts_data->system_adaptor->strain.grad();
+            auto virial_tensor = this->system_adaptor->strain.grad();
             assert(virial_tensor.is_cpu() && virial_tensor.scalar_type() == torch::kFloat64);
             auto predicted_virial = virial_tensor.accessor<double, 2>();
 

--- a/src/ML-METATENSOR/pair_metatensor.h
+++ b/src/ML-METATENSOR/pair_metatensor.h
@@ -21,6 +21,15 @@ PairStyle(metatensor, PairMetatensor);
 
 #include "pair.h"
 
+#include <vector>
+
+// this is the actual namespace where `torch::Device` is defined
+namespace c10 {
+    class Device;
+
+    enum class DeviceType: int8_t;
+}
+
 namespace LAMMPS_NS {
 class MetatensorSystemAdaptor;
 struct PairMetatensorData;
@@ -38,12 +47,23 @@ public:
     void init_list(int id, NeighList *ptr) override;
 
     void allocate();
-private:
+
+protected:
+    // get the set of devices both available on the current machine and supported
+    // by the model
+    std::vector<c10::DeviceType> available_devices();
+
+    // pick the correct device to use from the user request (or nullptr) in
+    // `pair_style metatensor`
+    virtual void pick_device(c10::Device* device, const char* requested);
+
     PairMetatensorData* mts_data;
     NeighList *mts_list;
 
     // mapping from LAMMPS types to metatensor types
     int32_t *type_mapping;
+    // adaptor from LAMMPS system to metatensor's
+    std::unique_ptr<MetatensorSystemAdaptor> system_adaptor;
 };
 
 }    // namespace LAMMPS_NS


### PR DESCRIPTION
This PR implements an experimental kokkos-metatensor interface.

Most of the accelerated code is written in torch as opposed to Kokkos, as torch wraps specialized CUDA kernels that are, most often, faster than the code generated by Kokkos.
Only the version with the neighbor remapping is implemented (for now), as the interface is relatively fast, so that in most cases not remapping would cripple the model way
more than slowing down the interface.

The exact consistency among the original interface, the `Kokkos::Cuda` interface and the `Kokkos::OpenMP` interface can be verified by running the metatensor and metatensor-kokkos examples.

I also added a readme in the examples folder to document the whole building and running procedure. I think this would be a very good place to point people to so they can compile and run the code. We can then remove it again in the future if needed

I tried to format with `clang-format` but I get way too many changes and I think I'm doing something wrong, so I didn't format in the end