### PR TITLE
Allow to use externally-provided metatensor_torch

### DIFF
--- a/cmake/Modules/Packages/ML-METATENSOR.cmake
+++ b/cmake/Modules/Packages/ML-METATENSOR.cmake
@@ -7,9 +7,9 @@ endif()
 if (BUILD_OMP AND APPLE)
     message(FATAL_ERROR
         "Can not enable both BUILD_OMP and PGK_ML-METATENSOR on Apple systems, "
-        "since this results in two different versions of libiomp5.dylib (one "
+        "since this results in two different versions of the OpenMP library (one "
         "from the system and one from Torch) being linked to the final "
-        "executable, which then segfaults"
+        "executable, which then crashes"
     )
 endif()
 
@@ -41,28 +41,42 @@ endif()
 
 ########### definition of metatensor and metatensor-torch targets ###########
 
-include(FetchContent)
-
-set(URL_BASE "https://github.com/lab-cosmo/metatensor/releases/download")
-
 set(METATENSOR_CORE_VERSION "0.1.12")
-FetchContent_Declare(metatensor
-    URL ${URL_BASE}/metatensor-core-v${METATENSOR_CORE_VERSION}/metatensor-core-cxx-${METATENSOR_CORE_VERSION}.tar.gz
-    URL_HASH SHA1=aec0963624f7fcd470e71471eb22b8912aec912e
-)
-
-message(STATUS "Fetching metatensor v${METATENSOR_CORE_VERSION} from github")
-FetchContent_MakeAvailable(metatensor)
-
-
 set(METATENSOR_TORCH_VERSION "0.7.3")
-FetchContent_Declare(metatensor-torch
-    URL ${URL_BASE}/metatensor-torch-v${METATENSOR_TORCH_VERSION}/metatensor-torch-cxx-${METATENSOR_TORCH_VERSION}.tar.gz
-    URL_HASH SHA1=26f989650d29008ab640aa6bdea706f88adc4fba
-)
 
-message(STATUS "Fetching metatensor-torch v${METATENSOR_TORCH_VERSION} from github")
-FetchContent_MakeAvailable(metatensor-torch)
+set(DOWNLOAD_METATENSOR_DEFAULT ON)
+find_package(metatensor_torch QUIET ${METATENSOR_TORCH_VERSION})
+if (metatensor_torch_FOUND)
+    set(DOWNLOAD_METATENSOR_DEFAULT OFF)
+endif()
+
+
+option(DOWNLOAD_METATENSOR "Download metatensor package instead of using an already installed one" ${DOWNLOAD_METATENSOR_DEFAULT})
+
+if (DOWNLOAD_METATENSOR)
+    include(FetchContent)
+
+    set(URL_BASE "https://github.com/lab-cosmo/metatensor/releases/download")
+
+    FetchContent_Declare(metatensor
+        URL ${URL_BASE}/metatensor-core-v${METATENSOR_CORE_VERSION}/metatensor-core-cxx-${METATENSOR_CORE_VERSION}.tar.gz
+        URL_HASH SHA1=aec0963624f7fcd470e71471eb22b8912aec912e
+    )
+
+    message(STATUS "Fetching metatensor v${METATENSOR_CORE_VERSION} from github")
+    FetchContent_MakeAvailable(metatensor)
+
+    FetchContent_Declare(metatensor-torch
+        URL ${URL_BASE}/metatensor-torch-v${METATENSOR_TORCH_VERSION}/metatensor-torch-cxx-${METATENSOR_TORCH_VERSION}.tar.gz
+        URL_HASH SHA1=26f989650d29008ab640aa6bdea706f88adc4fba
+    )
+
+    message(STATUS "Fetching metatensor-torch v${METATENSOR_TORCH_VERSION} from github")
+    FetchContent_MakeAvailable(metatensor-torch)
+else()
+    # make sure to fail the configuration if cmake can not find metatensor-torch
+    find_package(metatensor_torch REQUIRED ${METATENSOR_TORCH_VERSION})
+endif()
 
 
 ################ lammps target modifications ################

--- a/doc/src/Build_extras.rst
+++ b/doc/src/Build_extras.rst
@@ -1120,6 +1120,13 @@ https://pytorch.org/get-started/locally/.
 
          -DPKG_ML-METATENSOR=ON
          -DCMAKE_PREFIX_PATH="$TORCH_PREFIX"
+         -DLAMMPS_INSTALL_RPATH=ON
+
+      By default, this code will try to find the metatensor libraries on your
+      system and use them. If cmake can not find the libraries, it will download
+      and build them as part of the main LAMMPS build. If you want, you can
+      control this behavior using `-DDOWNLOAD_METATENSOR=ON` to always force a
+      download and `-DDOWNLOAD_METATENSOR=OFF` to prevent any download.
 
    .. tab:: Traditional make
 


### PR DESCRIPTION
@PicoCentauri and @abmazitov this should allow to use libmetatensor-torch from conda directly instead of rebuilding.