### PR TITLE
Propagate compile flags from metatensor-torch all the way to lmp

### DIFF
--- a/cmake/Modules/Packages/ML-METATENSOR.cmake
+++ b/cmake/Modules/Packages/ML-METATENSOR.cmake
@@ -81,4 +81,4 @@ endif()
 
 ################ lammps target modifications ################
 
-target_link_libraries(lammps PRIVATE metatensor_torch)
+target_link_libraries(lammps PUBLIC metatensor_torch)


### PR DESCRIPTION
Otherwise the `_GLIBCXX_USE_CXX11_ABI` flag from torch is not used when compiling `main.cpp`