### PR TITLE
Do not use transposed neighbors in kokkos

### DIFF
--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -109,7 +109,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_remap_kk(metatomi
         torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
     ).to(this->device_);
 
-    auto neighbors_kk = list->d_neighbors_transpose;
+    auto neighbors_kk = list->d_neighbors;
     auto max_number_of_neighbors = list->maxneighs;
 
     auto neighbors = torch::zeros(

--- a/src/KOKKOS/pair_metatomic_kokkos.cpp
+++ b/src/KOKKOS/pair_metatomic_kokkos.cpp
@@ -18,7 +18,6 @@
 #include "pair_metatomic_kokkos.h"
 
 #include "error.h"
-#include "kokkos.h"
 #include "neigh_request.h"
 #include "atom_masks.h"
 
@@ -42,10 +41,7 @@ template<typename T, class DeviceType>
 using UnmanagedView = Kokkos::View<T, Kokkos::LayoutRight, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
 template<class DeviceType>
-PairMetatomicKokkos<DeviceType>::PairMetatomicKokkos(LAMMPS* lmp): PairMetatomic(lmp) {
-    // this will allow us to receive the NL in a GPU-friendly format
-    this->lmp->kokkos->neigh_transpose = 1;
-}
+PairMetatomicKokkos<DeviceType>::PairMetatomicKokkos(LAMMPS* lmp): PairMetatomic(lmp) {}
 
 template<class DeviceType>
 PairMetatomicKokkos<DeviceType>::~PairMetatomicKokkos() {}


### PR DESCRIPTION
Do not use `d_neighbors_transpose` in the kokkos pair style. For some reason it is not set when running `pair_style hybrid/overlay/kk`; and we are the only users of it in the code base. The "standard" `d_neighbors` seems to have the exact same data, so we can just use that!

From some basic tests, on CPU with the LJ model, the performance also seems to be the same.