### PR TITLE
Fix warning message about uncertainties

### DIFF
--- a/src/ML-METATOMIC/pair_metatomic.cpp
+++ b/src/ML-METATOMIC/pair_metatomic.cpp
@@ -718,7 +718,7 @@ void PairMetatomic::compute(int eflag, int vflag) {
 
             error->warning(FLERR,
                 "The uncertainty on atomic energies for {} are larger than "
-                "the threshold of {}. Be careful when analyzing the results, "
+                "the threshold of {} eV/atom. Be careful when analyzing the results, "
                 "and consider retraining the model to better describe these "
                 "configurations.",
                 atoms_message.str(), mta_data->uncertainty_threshold


### PR DESCRIPTION
```
WARNING: The uncertainty on atomic energies for atoms at index [22, 36, 37, 89, 91, 101, 104, 128, 130, 216] and 53 more are larger than the threshold of 0.1.
```
This warning isn't too descriptive. Why is 53 separated from the others? And 0.1 what?