### PR TITLE
Faster system conversions from LAMMPS to metatomic

### DIFF
--- a/examples/PACKAGES/metatomic/in.metatomic
+++ b/examples/PACKAGES/metatomic/in.metatomic
@@ -7,8 +7,7 @@ region box block 0 2 0 2 0 2
 create_box 1 box
 create_atoms 1 box
 
-labelmap atom 1 Ni
-mass Ni 58.693
+mass 1 58.693
 
 velocity all create 123 42
 

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -15,74 +15,23 @@
    Contributing authors: Guillaume Fraux <guillaume.fraux@epfl.ch>
                          Filippo Bigi <filippo.bigi@epfl.ch>
 ------------------------------------------------------------------------- */
+
 #include "metatomic_system_kokkos.h"
+#include "memory_kokkos.h"
 #include "metatomic_timer.h"
 
-#include "domain.h"
-#include "comm.h"
+#include "atom_masks.h"
 #include "atom_kokkos.h"
+#include "comm.h"
+#include "domain.h"
+#include "error.h"
 
 #include <torch/cuda.h>
 
 using namespace LAMMPS_NS;
 
-/// Compute the inverse of the cell matrix of the system, accounting for
-/// non-periodic directions by setting the corresponding rows to an unit vector
-/// orthogonal to the periodic directions. This is used to compute the cell
-/// shifts of neighbor pairs.
-static torch::Tensor cell_inverse(const metatomic_torch::System& system) {
-    auto cell = system->cell().clone();
-    auto periodic = system->pbc();
-
-    // find number of periodic directions and their indices
-    int n_periodic = 0;
-    int periodic_idx_1 = -1;
-    int periodic_idx_2 = -1;
-    for (int i = 0; i < 3; ++i) {
-        if (periodic[i].item<bool>()) {
-            n_periodic += 1;
-            if (periodic_idx_1 == -1) {
-                periodic_idx_1 = i;
-            } else if (periodic_idx_2 == -1) {
-                periodic_idx_2 = i;
-            }
-        }
-    }
-
-    // adjust the box matrix to have a simple orthogonal dimension along
-    // non-periodic directions
-    if (n_periodic == 0) {
-        return torch::eye(3, cell.options());
-    } else if (n_periodic == 1) {
-        assert(periodic_idx_1 != -1);
-        // Make the two non-periodic directions orthogonal to the periodic one
-        auto a = cell[periodic_idx_1];
-        auto b = torch::tensor({0, 1, 0}, cell.options());
-        if (torch::abs(torch::dot(a / a.norm(), b)).item<double>() > 0.9) {
-            b = torch::tensor({0, 0, 1}, cell.options());
-        }
-        auto c = torch::cross(a, b);
-        c /= c.norm();
-        b = torch::cross(c, a);
-        b /= b.norm();
-
-        // Assign back to the cell picking the "non-periodic" indices without ifs
-        cell[(periodic_idx_1 + 1) % 3] = b;
-        cell[(periodic_idx_1 + 2) % 3] = c;
-    } else if (n_periodic == 2) {
-        assert(periodic_idx_1 != -1 && periodic_idx_2 != -1);
-        // Make the one non-periodic direction orthogonal to the two periodic ones
-        auto a = cell[periodic_idx_1];
-        auto b = cell[periodic_idx_2];
-        auto c = torch::cross(a, b);
-        c /= c.norm();
-
-        // Assign back to the matrix picking the "non-periodic" index without ifs
-        cell[(3 - periodic_idx_1 - periodic_idx_2)] = c;
-    }
-
-    return cell.inverse();
-}
+template<typename T, class DeviceType>
+using UnmanagedView = Kokkos::View<T, Kokkos::LayoutRight, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
 template<typename T, class DeviceType>
 using UnmanagedView = Kokkos::View<T, Kokkos::LayoutRight, DeviceType, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
@@ -104,202 +53,321 @@ MetatomicSystemAdaptorKokkos<DeviceType>::MetatomicSystemAdaptorKokkos(LAMMPS *l
 }
 
 template<class DeviceType>
+void MetatomicSystemAdaptorKokkos<DeviceType>::add_nl_request(double cutoff, metatomic_torch::NeighborListOptions request) {
+    if (cutoff > options_.interaction_range) {
+        error->one(FLERR,
+            "Invalid metatomic model: one of the requested neighbor lists "
+            "has a cutoff ({}) larger than the model interaction range ({})",
+            cutoff, options_.interaction_range
+        );
+    } else if (cutoff < 0 || !std::isfinite(cutoff)) {
+        error->one(FLERR,
+            "model requested an invalid cutoff for neighbors list: {} "
+            "(cutoff in model units is {})",
+            cutoff, request->cutoff()
+        );
+    }
+
+    nl_requests_kk_.push_back({
+        cutoff,
+        request,
+        /*samples = */ {},
+        /*distances_f64 = */ {},
+        /*distances_f32 = */ {},
+    });
+}
+
+
+template<class DeviceType>
 void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torch::System& system, NeighListKokkos<DeviceType>* list) {
     auto _ = MetatomicTimer("converting kokkos neighbors list");
+
     auto dtype = system->positions().scalar_type();
-
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
+    auto max_number_of_neighbors = list->maxneighs;
 
-    // auto original_id = torch::from_blob(
-    //     original_atom_id_.data(),
-    //     {total_n_atoms},
-    //     torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
-    // ).to(this->device_);
+    auto original_id = UnmanagedView<int*, LMPHostType>(
+        original_atom_id_.data(),
+        original_atom_id_.size()
+    );
+    auto d_original_id = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", original_atom_id_.size());
+    Kokkos::deep_copy(d_original_id, original_id);
 
-    // auto lmp_to_mta = torch::from_blob(
-    //     lmp_to_mta_.data(),
-    //     {total_n_atoms},
-    //     torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
-    // ).to(this->device_);
+    auto lmp_to_mta = UnmanagedView<int*, LMPHostType>(
+        lmp_to_mta_.data(),
+        lmp_to_mta_.size()
+    );
+    auto d_lmp_to_mta = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", lmp_to_mta_.size());
+    Kokkos::deep_copy(d_lmp_to_mta, lmp_to_mta);
 
-    // auto neighbors_kk = list->d_neighbors;
-    // auto max_number_of_neighbors = list->maxneighs;
 
-    // auto neighbors = torch::zeros(
-    //     {total_n_atoms, max_number_of_neighbors},
-    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    // );
-    // // mask neighbors_kk with NEIGHMASK. Torch doesn't have this functionality, we do it in Kokkos
-    // auto neighbors_kk_masked = UnmanagedView<int32_t**, DeviceType>(
-    //     neighbors.template data_ptr<int32_t>(),
-    //     total_n_atoms,
-    //     max_number_of_neighbors
-    // );
-    // Kokkos::parallel_for(
-    //     Kokkos::MDRangePolicy({0, 0}, {total_n_atoms, max_number_of_neighbors}),
-    //     KOKKOS_LAMBDA(size_t i, size_t j) {
-    //         neighbors_kk_masked(i, j) = neighbors_kk(i, j) & NEIGHMASK;
-    //     }
-    // );
+    auto cell_inv = this->cell_inverse();
+    auto d_cell_inv = Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>("cell_inv", 3, 3);
+    Kokkos::deep_copy(
+        d_cell_inv,
+        UnmanagedView<double**, LMPHostType>(reinterpret_cast<double*>(cell_inv.data()), 3, 3)
+    );
 
-    // // Convert NL-related data to torch tensors
-    // auto numneigh = torch::from_blob(
-    //     list->d_numneigh.data(),
-    //     {total_n_atoms},
-    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    // );
-    // auto ilist = torch::from_blob(
-    //     list->d_ilist.data(),
-    //     {total_n_atoms},
-    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    // );
+    auto x = atomKK->k_x.view<DeviceType>();
+    auto cell_shifts = KOKKOS_LAMBDA(
+        const Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>& cell_inv,
+        const double pair_shift[3],
+        int32_t shift_out[3]
+    ) {
+        shift_out[0] = static_cast<int32_t>(std::round(
+            cell_inv(0, 0) * pair_shift[0] +
+            cell_inv(0, 1) * pair_shift[1] +
+            cell_inv(0, 2) * pair_shift[2]
+        ));
+        shift_out[1] = static_cast<int32_t>(std::round(
+            cell_inv(1, 0) * pair_shift[0] +
+            cell_inv(1, 1) * pair_shift[1] +
+            cell_inv(1, 2) * pair_shift[2]
+        ));
+        shift_out[2] = static_cast<int32_t>(std::round(
+            cell_inv(2, 0) * pair_shift[0] +
+            cell_inv(2, 1) * pair_shift[1] +
+            cell_inv(2, 2) * pair_shift[2]
+        ));
+    };
 
-    // auto k_x = atomKK->k_x.view<DeviceType>();
-    // auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(this->device_);
-    // auto x = torch::from_blob(k_x.data(), {total_n_atoms, 3}, tensor_options);
-    // auto cell_inv = cell_inverse(system);
+    for (auto& nl: nl_requests_kk_) {
+        auto cutoff2 = nl.cutoff * nl.cutoff;
+        auto full_list = nl.options->full_list();
 
-    // // convert from LAMMPS NL format to metatomic NL format
-    // auto expanded_arange = torch::arange(
-    //     max_number_of_neighbors,
-    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    // ).unsqueeze(0).expand({total_n_atoms, -1});
-    // auto neighbor_2d_mask = expanded_arange < numneigh.unsqueeze(1);
+        auto cutoff_ratio = nl.cutoff / options_.interaction_range;
+        size_t max_n_pairs = total_n_atoms * list->maxneighs;
+        // Allocate for a much smaller number of pairs to avoid wasting memory
+        // (especially when the interaction range is much larger than the NL
+        // cutoff)
+        auto pairs_capacity = std::max(
+            std::max(
+                static_cast<size_t>(max_n_pairs * cutoff_ratio / 1000),
+                100ul
+            ),
+            nl.samples.extent(0)
+        );
 
-    // auto expanded_arange_other_dim = torch::arange(
-    //     total_n_atoms,
-    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    // ).unsqueeze(1).expand({-1, max_number_of_neighbors});
-    // auto index_for_ilist = expanded_arange_other_dim.masked_select(neighbor_2d_mask);
+        // actual number of pairs we found
+        auto n_pairs = Kokkos::DualView<int64_t, LMPDeviceType>("n_pairs");
+        auto d_n_pairs = n_pairs.view_device();
+        auto h_n_pairs = n_pairs.view_host();
 
-    // auto centers_id = ilist.index_select(0, index_for_ilist);
-    // auto neighbors_id = neighbors.masked_select(neighbor_2d_mask);
+        auto processed_all_pairs = Kokkos::DualView<bool, LMPDeviceType>("processed_all_pairs");
+        auto d_processed_all_pairs = processed_all_pairs.view_device();
+        auto h_processed_all_pairs = processed_all_pairs.view_host();
 
-    // // change centers and neighbors to the original atom ids
-    // auto centers_original_id = original_id.index_select(0, centers_id);
-    // auto neighbors_original_id = original_id.index_select(0, neighbors_id);
+        Kokkos::deep_copy(h_processed_all_pairs, false);
+        processed_all_pairs.template modify<LMPHostType>();
+        processed_all_pairs.template sync<LMPDeviceType>();
 
-    for (auto& nl: nl_requests_) {
-        // // current values of various tensors, these change depending on full/half setting
-        // torch::Tensor centers_id_cur;
-        // torch::Tensor neighbors_id_cur;
-        // torch::Tensor centers_original_id_cur;
-        // torch::Tensor neighbors_original_id_cur;
+        while (!h_processed_all_pairs()) {
+            {
+                auto _ = MetatomicTimer("allocating caches for kokkos neighbors list (capacity for " + std::to_string(pairs_capacity) + " pairs)");
+                if (nl.samples.extent(0) < pairs_capacity) {
+                    MemoryKokkos::realloc_kokkos(nl.samples, "metatomic:samples", pairs_capacity, 5);
+                }
 
-        // // filtered tensors, i.e. only containing pairs actually below the cutoff
-        // torch::Tensor centers_original_id_filt_cur;
-        // torch::Tensor neighbors_original_id_filt_cur;
-        // torch::Tensor distances_filt_cur;
-        // torch::Tensor cell_shifts_cur;
+                if (dtype == torch::kFloat64) {
+                    if (nl.distances_f64.extent(0) < pairs_capacity) {
+                        MemoryKokkos::realloc_kokkos(nl.distances_f64, "metatomic:distances_f64", pairs_capacity, 3);
+                    }
+                } else if (dtype == torch::kFloat32) {
+                    if (nl.distances_f32.extent(0) < pairs_capacity) {
+                        MemoryKokkos::realloc_kokkos(nl.distances_f32, "metatomic:distances_f32", pairs_capacity, 3);
+                    }
+                } else {
+                    // should be unreachable
+                    error->one(FLERR, "invalid dtype, this is a bug");
+                }
+            }
 
-        // // other tensors that need to live across multiple timed sections
-        // torch::Tensor samples_indices;
-        // torch::Tensor samples_values;
-        // {
-        //     auto _ = MetatomicTimer("filtering LAMMPS neighbor list");
-        //     // half list mask, if necessary
-        //     auto full_list = nl.options->full_list();
+            auto _ = MetatomicTimer("filtering kokkos neighbors list");
 
-        //     if (full_list) {
-        //         centers_id_cur = centers_id;
-        //         neighbors_id_cur = neighbors_id;
-        //         centers_original_id_cur = centers_original_id;
-        //         neighbors_original_id_cur = neighbors_original_id;
-        //     } else {
-        //         auto half_list_mask = centers_original_id <= neighbors_original_id;
-        //         centers_id_cur = centers_id.masked_select(half_list_mask);
-        //         neighbors_id_cur = neighbors_id.masked_select(half_list_mask);
-        //         centers_original_id_cur = centers_original_id.masked_select(half_list_mask);
-        //         neighbors_original_id_cur = neighbors_original_id.masked_select(half_list_mask);
-        //     }
+            Kokkos::deep_copy(h_n_pairs, 0);
+            n_pairs.template modify<LMPHostType>();
+            n_pairs.template sync<LMPDeviceType>();
 
-        //     // distance mask
-        //     auto distances = x.index_select(0, neighbors_id_cur) - x.index_select(0, centers_id_cur);
-        //     auto cutoff_mask = torch::sum(distances.pow(2), 1) < nl.cutoff * nl.cutoff;
+            Kokkos::deep_copy(h_processed_all_pairs, true);
+            processed_all_pairs.template modify<LMPHostType>();
+            processed_all_pairs.template sync<LMPDeviceType>();
 
-        //     // index everything with the mask
-        //     auto centers_original_id_filt = centers_original_id_cur.masked_select(cutoff_mask);
-        //     auto neighbors_original_id_filt = neighbors_original_id_cur.masked_select(cutoff_mask);
-        //     auto distances_filt = distances.index({cutoff_mask, torch::indexing::Slice()});
+            Kokkos::parallel_for(
+                Kokkos::MDRangePolicy<DeviceType, Kokkos::Rank<2>>(
+                    {0, 0},
+                    {list->inum + list->gnum, max_number_of_neighbors}
+                ),
+                KOKKOS_LAMBDA(size_t ii, size_t jj) {
+                    if (jj >= list->d_numneigh[ii]) {
+                        return;
+                    }
 
-        //     // find filtered interatomic vectors using the original atoms
-        //     auto original_distances_filtered = x.index_select(0, neighbors_original_id_filt) - x.index_select(0, centers_original_id_filt);
+                    auto atom_i = list->d_ilist[ii];
+                    auto original_atom_i = d_original_id[atom_i];
+                    auto i_is_original = (atom_i == original_atom_i);
 
-        //     // cell shifts
-        //     auto pair_shifts = distances_filt - original_distances_filtered;
-        //     auto cell_shifts = pair_shifts.matmul(cell_inv);
-        //     cell_shifts = torch::round(cell_shifts).to(torch::kInt32);
+                    auto atom_j = list->d_neighbors(ii, jj) & NEIGHMASK;
+                    auto original_atom_j = d_original_id[atom_j];
+                    auto j_is_original = (atom_j == original_atom_j);
 
-        //     if (full_list) {
-        //         centers_original_id_filt_cur = centers_original_id_filt;
-        //         neighbors_original_id_filt_cur = neighbors_original_id_filt;
-        //         distances_filt_cur = distances_filt;
-        //         cell_shifts_cur = cell_shifts;
-        //     } else {
-        //         auto half_list_cell_mask = centers_original_id_filt > neighbors_original_id_filt;
-        //         auto pair_with_image_mask = centers_original_id_filt == neighbors_original_id_filt;
-        //         auto negative_half_space_mask = torch::sum(cell_shifts, 1) < 0;
-        //         // reproduce this mask (from MetatomicSystemAdaptor::setup_neighbors_remap) with torch:
-        //         // if ((shift[0] + shift[1] + shift[2] == 0) && (shift[2] < 0 || (shift[2] == 0 && shift[1] < 0)))
-        //         auto edge_mask = (
-        //             (torch::sum(cell_shifts, 1) == 0) & (
-        //                 (cell_shifts.index({torch::indexing::Slice(), 2}) < 0) | (
-        //                     cell_shifts.index({torch::indexing::Slice(), 2}) == 0 &
-        //                     cell_shifts.index({torch::indexing::Slice(), 1}) < 0
-        //                 )
-        //             )
-        //         );
-        //         auto final_mask = torch::logical_not(
-        //             half_list_cell_mask | (
-        //                 pair_with_image_mask & (negative_half_space_mask | edge_mask)
-        //             )
-        //         );
-        //         centers_original_id_filt_cur = centers_original_id_filt.masked_select(final_mask);
-        //         neighbors_original_id_filt_cur = neighbors_original_id_filt.masked_select(final_mask);
-        //         distances_filt_cur = distances_filt.index({final_mask, torch::indexing::Slice()});
-        //         cell_shifts_cur = cell_shifts.index({final_mask, torch::indexing::Slice()});
-        //     }
+                    if (!full_list && original_atom_i > original_atom_j) {
+                        // Remove extra pairs if the model requested half-lists
+                        return;
+                    }
 
-        //     // make sure all the sample are unique
-        //     samples_values = torch::concatenate({
-        //         lmp_to_mta.index_select(0, centers_original_id_filt_cur).unsqueeze(-1),
-        //         lmp_to_mta.index_select(0, neighbors_original_id_filt_cur).unsqueeze(-1),
-        //         cell_shifts_cur
-        //     }, /*dim=*/1);
+                    if (!i_is_original && !j_is_original) {
+                        // both atoms are periodic ghosts, skip the pair
+                        return;
+                    }
 
-        //     auto [samples_values_unique, samples_inverse, _counts] = torch::unique_dim(
-        //         samples_values, /*dim=*/0, /*sorted=*/true, /*return_inverse=*/true, /*return_counts=*/false
-        //     );
-        //     samples_values = samples_values_unique;
+                    if (!i_is_original && j_is_original) {
+                        // this pair will be accounted for when we will process
+                        // atom_j as the central atom
+                        return;
+                    }
 
-        //     auto permutation = torch::arange(samples_inverse.size(0), samples_inverse.options());
-        //     samples_inverse = samples_inverse.flip({0});
-        //     permutation = permutation.flip({0});
+                    double distance[3] = {
+                        x(atom_j, 0) - x(atom_i, 0),
+                        x(atom_j, 1) - x(atom_i, 1),
+                        x(atom_j, 2) - x(atom_i, 2),
+                    };
 
-        //     samples_indices = torch::empty(samples_values.size(0), samples_inverse.options());
-        //     samples_indices.scatter_(0, samples_inverse, permutation);
-        // }
+                    auto distance2 = (
+                        distance[0] * distance[0] +
+                        distance[1] * distance[1] +
+                        distance[2] * distance[2]
+                    );
+                    if (distance2 > cutoff2) {
+                        // LAMMPS neighbors list contains some pairs after the
+                        // cutoff, we filter them here
+                        return;
+                    }
 
-        int64_t n_pairs = 0;
+                    // Compute the cell shift for the pair.
+                    double shift_i[3] = {
+                        x(atom_i, 0) - x(original_atom_i, 0),
+                        x(atom_i, 1) - x(original_atom_i, 1),
+                        x(atom_i, 2) - x(original_atom_i, 2),
+                    };
+                    double shift_j[3] = {
+                        x(atom_j, 0) - x(original_atom_j, 0),
+                        x(atom_j, 1) - x(original_atom_j, 1),
+                        x(atom_j, 2) - x(original_atom_j, 2),
+                    };
+                    double pair_shift[3] = {
+                        shift_j[0] - shift_i[0],
+                        shift_j[1] - shift_i[1],
+                        shift_j[2] - shift_i[2],
+                    };
 
+                    int32_t shift[3] = {0, 0, 0};
+                    if (pair_shift[0] != 0 || pair_shift[1] != 0 || pair_shift[2] != 0) {
+                        cell_shifts(d_cell_inv, pair_shift, shift);
+
+                        if (!full_list && original_atom_i == original_atom_j) {
+                            // If a half neighbors list has been requested, do
+                            // not include the same pair between an atom and
+                            // it's periodic image twice with opposite cell
+                            // shifts (e.g. [1, -1, 1] and [-1, 1, -1]).
+                            //
+                            // Instead we pick pairs in the positive plan of
+                            // shifts.
+                            if (shift[0] + shift[1] + shift[2] < 0) {
+                                // drop shifts on the negative half-space
+                                return;
+                            }
+
+                            if ((shift[0] + shift[1] + shift[2] == 0)
+                                && (shift[2] < 0 || (shift[2] == 0 && shift[1] < 0))) {
+                                // drop shifts in the negative half plane or the
+                                // negative shift[1] axis.
+                                //
+                                // See below for a graphical representation: we are
+                                // keeping the shifts indicated with `O` and
+                                // dropping the ones indicated with `X`
+                                //
+                                //  O O O │ O O O
+                                //  O O O │ O O O
+                                //  O O O │ O O O
+                                // ─X─X─X─┼─O─O─O─
+                                //  X X X │ X X X
+                                //  X X X │ X X X
+                                //  X X X │ X X X
+                                return;
+                            }
+                        }
+                    }
+
+                    auto pair_i = Kokkos::atomic_fetch_add(&d_n_pairs(), 1);
+                    if (pair_i >= nl.samples.extent(0)) {
+                        // stop and re-allocate larger arrays
+                        d_processed_all_pairs() = false;
+                        return;
+                    }
+
+                    nl.samples(pair_i, 0) = d_lmp_to_mta[original_atom_i];
+                    nl.samples(pair_i, 1) = d_lmp_to_mta[original_atom_j];
+                    nl.samples(pair_i, 2) = shift[0];
+                    nl.samples(pair_i, 3) = shift[1];
+                    nl.samples(pair_i, 4) = shift[2];
+                    if (dtype == torch::kFloat64) {
+                        nl.distances_f64(pair_i, 0) = distance[0];
+                        nl.distances_f64(pair_i, 1) = distance[1];
+                        nl.distances_f64(pair_i, 2) = distance[2];
+                    } else {
+                        assert(dtype == torch::kFloat32);
+                        nl.distances_f32(pair_i, 0) = static_cast<float>(distance[0]);
+                        nl.distances_f32(pair_i, 1) = static_cast<float>(distance[1]);
+                        nl.distances_f32(pair_i, 2) = static_cast<float>(distance[2]);
+                    }
+                }
+            );
+
+            processed_all_pairs.template modify<LMPDeviceType>();
+            processed_all_pairs.template sync<LMPHostType>();
+            if (!h_processed_all_pairs()) {
+                pairs_capacity *= 2;
+            }
+        }
+
+        n_pairs.template modify<LMPDeviceType>();
+        n_pairs.template sync<LMPHostType>();
 
         auto samples_values = torch::from_blob(
-            nullptr, {n_pairs, 5}, torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+            nl.samples.data(), {h_n_pairs(), 5}, torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
         );
 
-        auto distances = torch::from_blob(
-            nullptr, {n_pairs, 3}, torch::TensorOptions().dtype(dtype).device(this->device_)
-        );
+        torch::Tensor distances;
+        if (dtype == torch::kFloat64) {
+            distances = torch::from_blob(
+                nl.distances_f64.data(), {h_n_pairs(), 3, 1}, torch::TensorOptions().dtype(dtype).device(this->device_)
+            );
+        } else if (dtype == torch::kFloat32) {
+            distances = torch::from_blob(
+                nl.distances_f32.data(), {h_n_pairs(), 3, 1}, torch::TensorOptions().dtype(dtype).device(this->device_)
+            );
+        } else {
+            // should be unreachable
+            error->one(FLERR, "invalid dtype, this is a bug");
+        }
 
         // wrap into metatensor data structures
         torch::intrusive_ptr<metatensor_torch::LabelsHolder> samples;
         {
-            auto _ = MetatomicTimer("creating samples Labels (" +  std::to_string(n_pairs) + " pairs)");
-            samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
-                std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
-                samples_values,
-                metatensor::assume_unique{}
-            );
+            auto _ = MetatomicTimer("creating samples Labels (" +  std::to_string(h_n_pairs()) + " pairs)");
+
+            if (options_.check_consistency) {
+                samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+                    std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
+                    samples_values
+                );
+            } else {
+                samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+                    std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
+                    samples_values,
+                    metatensor::assume_unique{}
+                );
+            }
         }
 
         torch::intrusive_ptr<metatensor_torch::TensorBlockHolder> neighbors;
@@ -316,8 +384,11 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             );
         }
 
-        metatomic_torch::register_autograd_neighbors(system, neighbors, options_.check_consistency);
-        system->add_neighbor_list(nl.options, neighbors);
+        {
+            auto _ = MetatomicTimer("registering neighbors in System");
+            metatomic_torch::register_autograd_neighbors(system, neighbors, options_.check_consistency);
+            system->add_neighbor_list(nl.options, neighbors);
+        }
     }
 }
 
@@ -369,6 +440,8 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
         torch::tensor({0.0}, tensor_options)
     );
 
+    // make sure to sync the updated tags to host
+    atomKK->sync(ExecutionSpaceFromDevice<LMPHostType>::space, TAG_MASK);
     this->guess_periodic_ghosts();
 
     // Only keep the atoms which are not periodic images of other atoms

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -192,21 +192,23 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             processed_all_pairs.template modify<LMPHostType>();
             processed_all_pairs.template sync<LMPDeviceType>();
 
+            auto d_numneigh = list->d_numneigh;
+            auto d_ilist = list->d_ilist;
+            auto d_neighbors = list->d_neighbors;
+
             Kokkos::parallel_for(
                 Kokkos::MDRangePolicy<DeviceType, Kokkos::Rank<2>>(
                     {0, 0},
                     {list->inum + list->gnum, max_number_of_neighbors}
                 ),
                 KOKKOS_LAMBDA(size_t ii, size_t jj) {
-                    if (jj >= list->d_numneigh[ii]) {
+                    if (jj >= d_numneigh[ii]) {
                         return;
                     }
-
-                    auto atom_i = list->d_ilist[ii];
+                    auto atom_i = d_ilist[ii];
                     auto original_atom_i = d_original_id[atom_i];
                     auto i_is_original = (atom_i == original_atom_i);
-
-                    auto atom_j = list->d_neighbors(ii, jj) & NEIGHMASK;
+                    auto atom_j = d_neighbors(ii, jj) & NEIGHMASK;
                     auto original_atom_j = d_original_id[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -110,57 +110,14 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
 
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
 
-    {
-        auto _ = MetatomicTimer("identifying ghosts and real atoms");
-        /*-------------- this will be done on CPU for now ------------------------*/
-        // The hashmap in the following code is not easy to implement in either Kokkos or torch
-        // The cost of this section seems to be very low anyway
-
-        // Collect the local atom id of all local & ghosts atoms, mapping ghosts
-        // atoms which are periodic images of local atoms back to the local atoms.
-        //
-        // Metatomic expects pairs corresponding to periodic atoms to be between
-        // the main atoms, but using the actual distance vector between the atom and
-        // the ghost.
-        original_atom_id_.clear();
-        original_atom_id_.reserve(total_n_atoms);
-
-        // identify all local atom by their LAMMPS atom tag.
-        local_atoms_tags_.clear();
-        for (int i=0; i<atom->nlocal; i++) {
-            original_atom_id_.emplace_back(i);
-            local_atoms_tags_.emplace(atom->tag[i], i);
-        }
-
-        // now loop over ghosts & map them back to the main cell if needed
-        ghost_atoms_tags_.clear();
-        for (int i=atom->nlocal; i<total_n_atoms; i++) {
-            auto tag = atom->tag[i];
-            auto it = local_atoms_tags_.find(tag);
-            if (it != local_atoms_tags_.end()) {
-                // this is the periodic image of an atom already owned by this domain
-                original_atom_id_.emplace_back(it->second);
-            } else {
-                // this can either be a periodic image of an atom owned by another
-                // domain, or directly an atom from another domain. Since we can not
-                // really distinguish between these, we take the first atom as the
-                // "main" one and remap all atoms with the same tag to the first one
-                auto it = ghost_atoms_tags_.find(tag);
-                if (it != ghost_atoms_tags_.end()) {
-                    // we already found this atom elsewhere in the system
-                    original_atom_id_.emplace_back(it->second);
-                } else {
-                    // this is the first time we are seeing this atom
-                    original_atom_id_.emplace_back(i);
-                    ghost_atoms_tags_.emplace(tag, i);
-                }
-            }
-        }
-    }
-    /*----------- end of "this will be done on CPU for now" --------------*/
-
     auto original_id = torch::from_blob(
         original_atom_id_.data(),
+        {total_n_atoms},
+        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
+    ).to(this->device_);
+
+    auto lmp_to_mta = torch::from_blob(
+        lmp_to_mta_.data(),
         {total_n_atoms},
         torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
     ).to(this->device_);
@@ -197,7 +154,9 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
     );
 
-    auto x = system->positions().detach();
+    auto k_x = atomKK->k_x.view<DeviceType>();
+    auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(this->device_);
+    auto x = torch::from_blob(k_x.data(), {total_n_atoms, 3}, tensor_options);
     auto cell_inv = cell_inverse(system);
 
     // convert from LAMMPS NL format to metatomic NL format
@@ -306,8 +265,8 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
 
             // make sure all the sample are unique
             samples_values = torch::concatenate({
-                centers_original_id_filt_cur.unsqueeze(-1),
-                neighbors_original_id_filt_cur.unsqueeze(-1),
+                lmp_to_mta.index_select(0, centers_original_id_filt_cur).unsqueeze(-1),
+                lmp_to_mta.index_select(0, neighbors_original_id_filt_cur).unsqueeze(-1),
                 cell_shifts_cur
             }, /*dim=*/1);
 
@@ -380,11 +339,7 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
     auto k_x = atomKK->k_x.view<DeviceType>();
     auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(this->device_);
 
-    this->positions = torch::from_blob(
-        k_x.data(), {total_n_atoms, 3},
-        // requires_grad=true since we always need gradients w.r.t. positions
-        tensor_options.requires_grad(options_.requires_grad)
-    );
+    this->positions = torch::from_blob(k_x.data(), {total_n_atoms, 3}, tensor_options);
 
     auto cell = torch::zeros({3, 3}, tensor_options);
     cell[0][0] = domain->xprd;
@@ -396,9 +351,6 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
     cell[2][1] = domain->yz;
     cell[2][2] = domain->zprd;
 
-    auto system_positions = this->positions.to(dtype);
-    cell = cell.to(dtype);
-
     // Periodic boundary conditions handling.
     auto pbc = torch::tensor(
         {domain->xperiodic, domain->yperiodic, domain->zperiodic},
@@ -407,8 +359,24 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
 
     cell.index_put_(
         {torch::logical_not(pbc)},
-        torch::tensor({0.0}, torch::TensorOptions().dtype(dtype).device(this->device_))
+        torch::tensor({0.0}, tensor_options)
     );
+
+    this->guess_periodic_ghosts();
+
+    // Only keep the atoms which are not periodic images of other atoms
+    auto mta_to_lmp_tensor = torch::from_blob(
+        mta_to_lmp.data(),
+        {static_cast<int64_t>(mta_to_lmp.size())},
+        torch::TensorOptions().dtype(torch::kInt).device(torch::kCPU)
+    ).to(this->device_);
+    this->atomic_types_ = this->atomic_types_.index_select(0, mta_to_lmp_tensor);
+    this->positions = this->positions.index_select(0, mta_to_lmp_tensor);
+
+    this->positions.set_requires_grad(options_.requires_grad);
+
+    auto system_positions = this->positions.to(dtype).to(device);
+    cell = cell.to(dtype);
 
     if (do_virial) {
         auto model_strain = this->strain.to(dtype);

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -110,183 +110,190 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
 
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
 
-    auto original_id = torch::from_blob(
-        original_atom_id_.data(),
-        {total_n_atoms},
-        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
-    ).to(this->device_);
+    // auto original_id = torch::from_blob(
+    //     original_atom_id_.data(),
+    //     {total_n_atoms},
+    //     torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
+    // ).to(this->device_);
 
-    auto lmp_to_mta = torch::from_blob(
-        lmp_to_mta_.data(),
-        {total_n_atoms},
-        torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
-    ).to(this->device_);
+    // auto lmp_to_mta = torch::from_blob(
+    //     lmp_to_mta_.data(),
+    //     {total_n_atoms},
+    //     torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
+    // ).to(this->device_);
 
-    auto neighbors_kk = list->d_neighbors;
-    auto max_number_of_neighbors = list->maxneighs;
+    // auto neighbors_kk = list->d_neighbors;
+    // auto max_number_of_neighbors = list->maxneighs;
 
-    auto neighbors = torch::zeros(
-        {total_n_atoms, max_number_of_neighbors},
-        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    );
-    // mask neighbors_kk with NEIGHMASK. Torch doesn't have this functionality, we do it in Kokkos
-    auto neighbors_kk_masked = UnmanagedView<int32_t**, DeviceType>(
-        neighbors.template data_ptr<int32_t>(),
-        total_n_atoms,
-        max_number_of_neighbors
-    );
-    Kokkos::parallel_for(
-        Kokkos::MDRangePolicy({0, 0}, {total_n_atoms, max_number_of_neighbors}),
-        KOKKOS_LAMBDA(size_t i, size_t j) {
-            neighbors_kk_masked(i, j) = neighbors_kk(i, j) & NEIGHMASK;
-        }
-    );
+    // auto neighbors = torch::zeros(
+    //     {total_n_atoms, max_number_of_neighbors},
+    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    // );
+    // // mask neighbors_kk with NEIGHMASK. Torch doesn't have this functionality, we do it in Kokkos
+    // auto neighbors_kk_masked = UnmanagedView<int32_t**, DeviceType>(
+    //     neighbors.template data_ptr<int32_t>(),
+    //     total_n_atoms,
+    //     max_number_of_neighbors
+    // );
+    // Kokkos::parallel_for(
+    //     Kokkos::MDRangePolicy({0, 0}, {total_n_atoms, max_number_of_neighbors}),
+    //     KOKKOS_LAMBDA(size_t i, size_t j) {
+    //         neighbors_kk_masked(i, j) = neighbors_kk(i, j) & NEIGHMASK;
+    //     }
+    // );
 
-    // Convert NL-related data to torch tensors
-    auto numneigh = torch::from_blob(
-        list->d_numneigh.data(),
-        {total_n_atoms},
-        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    );
-    auto ilist = torch::from_blob(
-        list->d_ilist.data(),
-        {total_n_atoms},
-        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    );
+    // // Convert NL-related data to torch tensors
+    // auto numneigh = torch::from_blob(
+    //     list->d_numneigh.data(),
+    //     {total_n_atoms},
+    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    // );
+    // auto ilist = torch::from_blob(
+    //     list->d_ilist.data(),
+    //     {total_n_atoms},
+    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    // );
 
-    auto k_x = atomKK->k_x.view<DeviceType>();
-    auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(this->device_);
-    auto x = torch::from_blob(k_x.data(), {total_n_atoms, 3}, tensor_options);
-    auto cell_inv = cell_inverse(system);
+    // auto k_x = atomKK->k_x.view<DeviceType>();
+    // auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(this->device_);
+    // auto x = torch::from_blob(k_x.data(), {total_n_atoms, 3}, tensor_options);
+    // auto cell_inv = cell_inverse(system);
 
-    // convert from LAMMPS NL format to metatomic NL format
-    auto expanded_arange = torch::arange(
-        max_number_of_neighbors,
-        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    ).unsqueeze(0).expand({total_n_atoms, -1});
-    auto neighbor_2d_mask = expanded_arange < numneigh.unsqueeze(1);
+    // // convert from LAMMPS NL format to metatomic NL format
+    // auto expanded_arange = torch::arange(
+    //     max_number_of_neighbors,
+    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    // ).unsqueeze(0).expand({total_n_atoms, -1});
+    // auto neighbor_2d_mask = expanded_arange < numneigh.unsqueeze(1);
 
-    auto expanded_arange_other_dim = torch::arange(
-        total_n_atoms,
-        torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
-    ).unsqueeze(1).expand({-1, max_number_of_neighbors});
-    auto index_for_ilist = expanded_arange_other_dim.masked_select(neighbor_2d_mask);
+    // auto expanded_arange_other_dim = torch::arange(
+    //     total_n_atoms,
+    //     torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+    // ).unsqueeze(1).expand({-1, max_number_of_neighbors});
+    // auto index_for_ilist = expanded_arange_other_dim.masked_select(neighbor_2d_mask);
 
-    auto centers_id = ilist.index_select(0, index_for_ilist);
-    auto neighbors_id = neighbors.masked_select(neighbor_2d_mask);
+    // auto centers_id = ilist.index_select(0, index_for_ilist);
+    // auto neighbors_id = neighbors.masked_select(neighbor_2d_mask);
 
-    // change centers and neighbors to the original atom ids
-    auto centers_original_id = original_id.index_select(0, centers_id);
-    auto neighbors_original_id = original_id.index_select(0, neighbors_id);
+    // // change centers and neighbors to the original atom ids
+    // auto centers_original_id = original_id.index_select(0, centers_id);
+    // auto neighbors_original_id = original_id.index_select(0, neighbors_id);
 
-    // The following code is a direct translation of the code in the non-Kokkos
-    // version (MetatomicSystemAdaptor::setup_neighbors_remap), but rewritten
-    // in torch to use the GPU
-    for (auto& cache: caches_) {
-        // current values of various tensors, these change depending on full/half setting
-        torch::Tensor centers_id_cur;
-        torch::Tensor neighbors_id_cur;
-        torch::Tensor centers_original_id_cur;
-        torch::Tensor neighbors_original_id_cur;
+    for (auto& nl: nl_requests_) {
+        // // current values of various tensors, these change depending on full/half setting
+        // torch::Tensor centers_id_cur;
+        // torch::Tensor neighbors_id_cur;
+        // torch::Tensor centers_original_id_cur;
+        // torch::Tensor neighbors_original_id_cur;
 
-        // filtered tensors, i.e. only containing pairs actually below the cutoff
-        torch::Tensor centers_original_id_filt_cur;
-        torch::Tensor neighbors_original_id_filt_cur;
-        torch::Tensor distances_filt_cur;
-        torch::Tensor cell_shifts_cur;
+        // // filtered tensors, i.e. only containing pairs actually below the cutoff
+        // torch::Tensor centers_original_id_filt_cur;
+        // torch::Tensor neighbors_original_id_filt_cur;
+        // torch::Tensor distances_filt_cur;
+        // torch::Tensor cell_shifts_cur;
 
-        // other tensors that need to live across multiple timed sections
-        torch::Tensor samples_indices;
-        torch::Tensor samples_values;
-        {
-            auto _ = MetatomicTimer("filtering LAMMPS neighbor list");
-            // half list mask, if necessary
-            auto full_list = cache.options->full_list();
+        // // other tensors that need to live across multiple timed sections
+        // torch::Tensor samples_indices;
+        // torch::Tensor samples_values;
+        // {
+        //     auto _ = MetatomicTimer("filtering LAMMPS neighbor list");
+        //     // half list mask, if necessary
+        //     auto full_list = nl.options->full_list();
 
-            if (full_list) {
-                centers_id_cur = centers_id;
-                neighbors_id_cur = neighbors_id;
-                centers_original_id_cur = centers_original_id;
-                neighbors_original_id_cur = neighbors_original_id;
-            } else {
-                auto half_list_mask = centers_original_id <= neighbors_original_id;
-                centers_id_cur = centers_id.masked_select(half_list_mask);
-                neighbors_id_cur = neighbors_id.masked_select(half_list_mask);
-                centers_original_id_cur = centers_original_id.masked_select(half_list_mask);
-                neighbors_original_id_cur = neighbors_original_id.masked_select(half_list_mask);
-            }
+        //     if (full_list) {
+        //         centers_id_cur = centers_id;
+        //         neighbors_id_cur = neighbors_id;
+        //         centers_original_id_cur = centers_original_id;
+        //         neighbors_original_id_cur = neighbors_original_id;
+        //     } else {
+        //         auto half_list_mask = centers_original_id <= neighbors_original_id;
+        //         centers_id_cur = centers_id.masked_select(half_list_mask);
+        //         neighbors_id_cur = neighbors_id.masked_select(half_list_mask);
+        //         centers_original_id_cur = centers_original_id.masked_select(half_list_mask);
+        //         neighbors_original_id_cur = neighbors_original_id.masked_select(half_list_mask);
+        //     }
 
-            // distance mask
-            auto distances = x.index_select(0, neighbors_id_cur) - x.index_select(0, centers_id_cur);
-            auto cutoff_mask = torch::sum(distances.pow(2), 1) < cache.cutoff*cache.cutoff;
+        //     // distance mask
+        //     auto distances = x.index_select(0, neighbors_id_cur) - x.index_select(0, centers_id_cur);
+        //     auto cutoff_mask = torch::sum(distances.pow(2), 1) < nl.cutoff * nl.cutoff;
 
-            // index everything with the mask
-            auto centers_original_id_filt = centers_original_id_cur.masked_select(cutoff_mask);
-            auto neighbors_original_id_filt = neighbors_original_id_cur.masked_select(cutoff_mask);
-            auto distances_filt = distances.index({cutoff_mask, torch::indexing::Slice()});
+        //     // index everything with the mask
+        //     auto centers_original_id_filt = centers_original_id_cur.masked_select(cutoff_mask);
+        //     auto neighbors_original_id_filt = neighbors_original_id_cur.masked_select(cutoff_mask);
+        //     auto distances_filt = distances.index({cutoff_mask, torch::indexing::Slice()});
 
-            // find filtered interatomic vectors using the original atoms
-            auto original_distances_filtered = x.index_select(0, neighbors_original_id_filt) - x.index_select(0, centers_original_id_filt);
+        //     // find filtered interatomic vectors using the original atoms
+        //     auto original_distances_filtered = x.index_select(0, neighbors_original_id_filt) - x.index_select(0, centers_original_id_filt);
 
-            // cell shifts
-            auto pair_shifts = distances_filt - original_distances_filtered;
-            auto cell_shifts = pair_shifts.matmul(cell_inv);
-            cell_shifts = torch::round(cell_shifts).to(torch::kInt32);
+        //     // cell shifts
+        //     auto pair_shifts = distances_filt - original_distances_filtered;
+        //     auto cell_shifts = pair_shifts.matmul(cell_inv);
+        //     cell_shifts = torch::round(cell_shifts).to(torch::kInt32);
 
-            if (full_list) {
-                centers_original_id_filt_cur = centers_original_id_filt;
-                neighbors_original_id_filt_cur = neighbors_original_id_filt;
-                distances_filt_cur = distances_filt;
-                cell_shifts_cur = cell_shifts;
-            } else {
-                auto half_list_cell_mask = centers_original_id_filt > neighbors_original_id_filt;
-                auto pair_with_image_mask = centers_original_id_filt == neighbors_original_id_filt;
-                auto negative_half_space_mask = torch::sum(cell_shifts, 1) < 0;
-                // reproduce this mask (from MetatomicSystemAdaptor::setup_neighbors_remap) with torch:
-                // if ((shift[0] + shift[1] + shift[2] == 0) && (shift[2] < 0 || (shift[2] == 0 && shift[1] < 0)))
-                auto edge_mask = (
-                    (torch::sum(cell_shifts, 1) == 0) & (
-                        (cell_shifts.index({torch::indexing::Slice(), 2}) < 0) | (
-                            cell_shifts.index({torch::indexing::Slice(), 2}) == 0 &
-                            cell_shifts.index({torch::indexing::Slice(), 1}) < 0
-                        )
-                    )
-                );
-                auto final_mask = torch::logical_not(
-                    half_list_cell_mask | (
-                        pair_with_image_mask & (negative_half_space_mask | edge_mask)
-                    )
-                );
-                centers_original_id_filt_cur = centers_original_id_filt.masked_select(final_mask);
-                neighbors_original_id_filt_cur = neighbors_original_id_filt.masked_select(final_mask);
-                distances_filt_cur = distances_filt.index({final_mask, torch::indexing::Slice()});
-                cell_shifts_cur = cell_shifts.index({final_mask, torch::indexing::Slice()});
-            }
+        //     if (full_list) {
+        //         centers_original_id_filt_cur = centers_original_id_filt;
+        //         neighbors_original_id_filt_cur = neighbors_original_id_filt;
+        //         distances_filt_cur = distances_filt;
+        //         cell_shifts_cur = cell_shifts;
+        //     } else {
+        //         auto half_list_cell_mask = centers_original_id_filt > neighbors_original_id_filt;
+        //         auto pair_with_image_mask = centers_original_id_filt == neighbors_original_id_filt;
+        //         auto negative_half_space_mask = torch::sum(cell_shifts, 1) < 0;
+        //         // reproduce this mask (from MetatomicSystemAdaptor::setup_neighbors_remap) with torch:
+        //         // if ((shift[0] + shift[1] + shift[2] == 0) && (shift[2] < 0 || (shift[2] == 0 && shift[1] < 0)))
+        //         auto edge_mask = (
+        //             (torch::sum(cell_shifts, 1) == 0) & (
+        //                 (cell_shifts.index({torch::indexing::Slice(), 2}) < 0) | (
+        //                     cell_shifts.index({torch::indexing::Slice(), 2}) == 0 &
+        //                     cell_shifts.index({torch::indexing::Slice(), 1}) < 0
+        //                 )
+        //             )
+        //         );
+        //         auto final_mask = torch::logical_not(
+        //             half_list_cell_mask | (
+        //                 pair_with_image_mask & (negative_half_space_mask | edge_mask)
+        //             )
+        //         );
+        //         centers_original_id_filt_cur = centers_original_id_filt.masked_select(final_mask);
+        //         neighbors_original_id_filt_cur = neighbors_original_id_filt.masked_select(final_mask);
+        //         distances_filt_cur = distances_filt.index({final_mask, torch::indexing::Slice()});
+        //         cell_shifts_cur = cell_shifts.index({final_mask, torch::indexing::Slice()});
+        //     }
 
-            // make sure all the sample are unique
-            samples_values = torch::concatenate({
-                lmp_to_mta.index_select(0, centers_original_id_filt_cur).unsqueeze(-1),
-                lmp_to_mta.index_select(0, neighbors_original_id_filt_cur).unsqueeze(-1),
-                cell_shifts_cur
-            }, /*dim=*/1);
+        //     // make sure all the sample are unique
+        //     samples_values = torch::concatenate({
+        //         lmp_to_mta.index_select(0, centers_original_id_filt_cur).unsqueeze(-1),
+        //         lmp_to_mta.index_select(0, neighbors_original_id_filt_cur).unsqueeze(-1),
+        //         cell_shifts_cur
+        //     }, /*dim=*/1);
 
-            auto [samples_values_unique, samples_inverse, _counts] = torch::unique_dim(
-                samples_values, /*dim=*/0, /*sorted=*/true, /*return_inverse=*/true, /*return_counts=*/false
-            );
-            samples_values = samples_values_unique;
+        //     auto [samples_values_unique, samples_inverse, _counts] = torch::unique_dim(
+        //         samples_values, /*dim=*/0, /*sorted=*/true, /*return_inverse=*/true, /*return_counts=*/false
+        //     );
+        //     samples_values = samples_values_unique;
 
-            auto permutation = torch::arange(samples_inverse.size(0), samples_inverse.options());
-            samples_inverse = samples_inverse.flip({0});
-            permutation = permutation.flip({0});
+        //     auto permutation = torch::arange(samples_inverse.size(0), samples_inverse.options());
+        //     samples_inverse = samples_inverse.flip({0});
+        //     permutation = permutation.flip({0});
 
-            samples_indices = torch::empty(samples_values.size(0), samples_inverse.options());
-            samples_indices.scatter_(0, samples_inverse, permutation);
-        }
+        //     samples_indices = torch::empty(samples_values.size(0), samples_inverse.options());
+        //     samples_indices.scatter_(0, samples_inverse, permutation);
+        // }
+
+        int64_t n_pairs = 0;
+
+
+        auto samples_values = torch::from_blob(
+            nullptr, {n_pairs, 5}, torch::TensorOptions().dtype(torch::kInt32).device(this->device_)
+        );
+
+        auto distances = torch::from_blob(
+            nullptr, {n_pairs, 3}, torch::TensorOptions().dtype(dtype).device(this->device_)
+        );
 
         // wrap into metatensor data structures
         torch::intrusive_ptr<metatensor_torch::LabelsHolder> samples;
         {
-            auto n_pairs = samples_values.size(0);
             auto _ = MetatomicTimer("creating samples Labels (" +  std::to_string(n_pairs) + " pairs)");
             samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
                 std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
@@ -300,7 +307,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             auto _ = MetatomicTimer("creating neighbors TensorBlock");
 
             neighbors = torch::make_intrusive<metatensor_torch::TensorBlockHolder>(
-                distances_filt_cur.index_select(0, samples_indices).unsqueeze(-1),
+                distances,
                 samples,
                 std::vector<metatensor_torch::Labels>{
                     metatensor_torch::LabelsHolder::create({"xyz"}, {{0}, {1}, {2}})->to(this->device_),
@@ -310,7 +317,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         }
 
         metatomic_torch::register_autograd_neighbors(system, neighbors, options_.check_consistency);
-        system->add_neighbor_list(cache.options, neighbors);
+        system->add_neighbor_list(nl.options, neighbors);
     }
 }
 

--- a/src/KOKKOS/metatomic_system_kokkos.h
+++ b/src/KOKKOS/metatomic_system_kokkos.h
@@ -72,11 +72,34 @@ template<> struct KokkosDeviceToTorch<Kokkos::Threads> {
 
 /* ---------------------------------------------------------------------- */
 
+// data for metatomic neighbors lists
+struct MetatomicNeighborsDataKokkos {
+    // single neighbors sample containing [i, j, S_a, S_b, S_c]
+    using sample_t = std::array<int32_t, 5>;
+
+    // cutoff for this NL in LAMMPS units
+    double cutoff;
+    // options of the NL as requested by the model
+    metatomic_torch::NeighborListOptions options;
+
+    // Below are cached allocations for the LAMMPS -> metatomic NL translation
+    // TODO: report memory usage for these?
+
+    Kokkos::View<int32_t**, Kokkos::LayoutRight, LMPDeviceType> samples;
+    // pairs distances vectors
+    Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType> distances_f64;
+    Kokkos::View<float**, Kokkos::LayoutRight, LMPDeviceType> distances_f32;
+};
+
 template<class DeviceType>
 class MetatomicSystemAdaptorKokkos : public MetatomicSystemAdaptor {
 public:
     MetatomicSystemAdaptorKokkos(LAMMPS *lmp, MetatomicSystemOptions options);
     ~MetatomicSystemAdaptorKokkos() override {}
+
+    void add_nl_request(
+        double cutoff, metatomic_torch::NeighborListOptions request
+    ) override;
 
     // Create a metatensor system matching the LAMMPS-Kokkos system data
     metatomic_torch::System system_from_lmp(
@@ -91,6 +114,9 @@ public:
 private:
     /// Torch device corresponding to the kokkos `DeviceType`
     torch::Device device_;
+
+    // allocations caches for all the NL requested by the model
+    std::vector<MetatomicNeighborsDataKokkos> nl_requests_kk_;
 };
 
 }    // namespace LAMMPS_NS

--- a/src/KOKKOS/pair_metatomic_kokkos.cpp
+++ b/src/KOKKOS/pair_metatomic_kokkos.cpp
@@ -109,12 +109,6 @@ void PairMetatomicKokkos<DeviceType>::pick_device(torch::Device& device, const c
     }
 }
 
-template<class DeviceType>
-void PairMetatomicKokkos<DeviceType>::pre_compute() {
-    /// Declare what we need to read from the atomKK object and what we will modify
-    this->atomKK->sync(ExecutionSpaceFromDevice<DeviceType>::space, datamask_read);
-    this->atomKK->modified(ExecutionSpaceFromDevice<DeviceType>::space, datamask_modify);
-}
 
 template<class DeviceType>
 void PairMetatomicKokkos<DeviceType>::store_forces(const at::Tensor& forces_tensor) {
@@ -142,7 +136,6 @@ void PairMetatomicKokkos<DeviceType>::store_forces(const at::Tensor& forces_tens
         using HostUnmanaged = UnmanagedView<int*, LMPHostType>;
         using DeviceUnmanaged = UnmanagedView<int*, DeviceType>;
         using DeviceView = Kokkos::View<int*, Kokkos::LayoutRight, DeviceType>;
-
 
         auto& mta_to_lmp = this->system_adaptor->mta_to_lmp;
         DeviceUnmanaged mta_to_lmp_kk;

--- a/src/KOKKOS/pair_metatomic_kokkos.cpp
+++ b/src/KOKKOS/pair_metatomic_kokkos.cpp
@@ -122,27 +122,53 @@ void PairMetatomicKokkos<DeviceType>::store_forces(const at::Tensor& forces_tens
     auto forces = forces_tensor.contiguous();
 
     auto forces_lammps_kk = this->atomKK->k_f.template view<DeviceType>();
-    auto forces_metatensor_kk = UnmanagedView<double**, DeviceType>(
+    auto forces_mta_kk = UnmanagedView<double**, DeviceType>(
         forces.template data_ptr<double>(),
         forces.size(0), 3
     );
 
-    int num_forces_to_update;
-    if (mta_data->non_conservative) {
-        num_forces_to_update = atomKK->nlocal;
-    } else {
-        num_forces_to_update = atomKK->nlocal + atomKK->nghost;
-    }
-
     double scale = this->scale;  // the GPU can't access the `this` pointer
     Kokkos::parallel_for(
-        num_forces_to_update,
+        atomKK->nlocal,
         KOKKOS_LAMBDA(size_t i) {
-            forces_lammps_kk(i, 0) += scale * forces_metatensor_kk(i, 0);
-            forces_lammps_kk(i, 1) += scale * forces_metatensor_kk(i, 1);
-            forces_lammps_kk(i, 2) += scale * forces_metatensor_kk(i, 2);
+            forces_lammps_kk(i, 0) += scale * forces_mta_kk(i, 0);
+            forces_lammps_kk(i, 1) += scale * forces_mta_kk(i, 1);
+            forces_lammps_kk(i, 2) += scale * forces_mta_kk(i, 2);
         }
     );
+
+    // in non-conservative mode we do not need to update forces on ghost atoms
+    if (!mta_data->non_conservative) {
+        using HostUnmanaged = UnmanagedView<int*, LMPHostType>;
+        using DeviceUnmanaged = UnmanagedView<int*, DeviceType>;
+        using DeviceView = Kokkos::View<int*, Kokkos::LayoutRight, DeviceType>;
+
+
+        auto& mta_to_lmp = this->system_adaptor->mta_to_lmp;
+        DeviceUnmanaged mta_to_lmp_kk;
+        DeviceView mta_to_lmp_device;
+        if constexpr (std::is_same_v<typename HostUnmanaged::memory_space, typename DeviceUnmanaged::memory_space>) {
+            mta_to_lmp_kk = DeviceUnmanaged(mta_to_lmp.data(), mta_to_lmp.size());
+        } else {
+            // make a copy of mta_to_lmp on device
+            mta_to_lmp_device = DeviceView("mta_to_lmp_kk", mta_to_lmp.size());
+            Kokkos::deep_copy(
+                mta_to_lmp_device,
+                HostUnmanaged(mta_to_lmp.data(), mta_to_lmp.size())
+            );
+            mta_to_lmp_kk = DeviceUnmanaged(mta_to_lmp_device.data(), mta_to_lmp.size());
+        }
+
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy(atomKK->nlocal, forces.size(0)),
+            KOKKOS_LAMBDA(size_t i) {
+                auto lmp_index = mta_to_lmp_kk[i];
+                forces_lammps_kk(lmp_index, 0) += scale * forces_mta_kk(i, 0);
+                forces_lammps_kk(lmp_index, 1) += scale * forces_mta_kk(i, 1);
+                forces_lammps_kk(lmp_index, 2) += scale * forces_mta_kk(i, 2);
+            }
+        );
+    }
 }
 
 

--- a/src/KOKKOS/pair_metatomic_kokkos.h
+++ b/src/KOKKOS/pair_metatomic_kokkos.h
@@ -50,7 +50,6 @@ public:
 
     void init_style() override;
 
-    void pre_compute() override;
     void store_forces(const at::Tensor& forces_tensor) override;
 
 private:

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -146,7 +146,7 @@ static std::array<std::array<double, 3>, 3> cell_inverse(Domain* domain) {
 MetatomicSystemAdaptor::MetatomicSystemAdaptor(LAMMPS *lmp, MetatomicSystemOptions options):
     Pointers(lmp),
     options_(std::move(options)),
-    caches_(),
+    nl_requests_(),
     atomic_types_(torch::zeros({0}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)))
 {
     auto tensor_options = torch::TensorOptions()
@@ -174,10 +174,9 @@ void MetatomicSystemAdaptor::add_nl_request(double cutoff, metatomic_torch::Neig
         );
     }
 
-    caches_.push_back({
+    nl_requests_.push_back({
         cutoff,
         request,
-        /*known_samples = */ {},
         /*samples = */ {},
         /*distances_f64 = */ {},
         /*distances_f32 = */ {},
@@ -277,31 +276,43 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
     auto total_n_atoms = atom->nlocal + atom->nghost;
     auto cell_inv = cell_inverse(domain);
 
-    for (auto& cache: caches_) {
+    for (auto& nl: nl_requests_) {
         {
             auto _ = MetatomicTimer("filtering LAMMPS neighbor list");
 
-            auto cutoff2 = cache.cutoff * cache.cutoff;
-            auto full_list = cache.options->full_list();
+            auto cutoff2 = nl.cutoff * nl.cutoff;
+            auto full_list = nl.options->full_list();
 
             // convert from LAMMPS neighbors list to metatomic format
-            cache.known_samples.clear();
-            cache.samples.clear();
-            cache.distances_f32.clear();
-            cache.distances_f64.clear();
+            nl.samples.clear();
+            nl.distances_f32.clear();
+            nl.distances_f64.clear();
             for (int ii=0; ii<(list->inum + list->gnum); ii++) {
                 auto atom_i = list->ilist[ii];
                 assert(atom_i < total_n_atoms);
                 auto original_atom_i = original_atom_id_[atom_i];
+                auto i_is_original = (atom_i == original_atom_i);
 
                 auto neighbors = list->firstneigh[ii];
                 for (int jj=0; jj<list->numneigh[ii]; jj++) {
                     auto atom_j = neighbors[jj] & NEIGHMASK;
                     assert(atom_j < total_n_atoms);
                     auto original_atom_j = original_atom_id_[atom_j];
+                    auto j_is_original = (atom_j == original_atom_j);
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
+                        continue;
+                    }
+
+                    if (!i_is_original && !j_is_original) {
+                        // both atoms are periodic ghosts, skip the pair
+                        continue;
+                    }
+
+                    if (!i_is_original && j_is_original) {
+                        // this pair will be accounted for when we will process
+                        // atom_j as the central atom
                         continue;
                     }
 
@@ -385,32 +396,26 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                         shift[2],
                     };
 
-                    // only add the pair if it is not already known. The same pair
-                    // can occur multiple time between two periodic ghosts shifted
-                    // around by the same amount, but we only want one of these pairs.
-                    if (cache.known_samples.insert(sample).second) {
-                        cache.samples.push_back(sample);
-
-                        if (dtype == torch::kFloat64) {
-                            cache.distances_f64.push_back(distance);
-                        } else if (dtype == torch::kFloat32) {
-                            cache.distances_f32.push_back({
-                                static_cast<float>(distance[0]),
-                                static_cast<float>(distance[1]),
-                                static_cast<float>(distance[2])
-                            });
-                        } else {
-                            // should be unreachable
-                            error->one(FLERR, "invalid dtype, this is a bug");
-                        }
+                    nl.samples.push_back(sample);
+                    if (dtype == torch::kFloat64) {
+                        nl.distances_f64.push_back(distance);
+                    } else if (dtype == torch::kFloat32) {
+                        nl.distances_f32.push_back({
+                            static_cast<float>(distance[0]),
+                            static_cast<float>(distance[1]),
+                            static_cast<float>(distance[2])
+                        });
+                    } else {
+                        // should be unreachable
+                        error->one(FLERR, "invalid dtype, this is a bug");
                     }
                 }
             }
         }
 
-        int64_t n_pairs = cache.samples.size();
+        int64_t n_pairs = nl.samples.size();
         auto samples_values = torch::from_blob(
-            reinterpret_cast<int32_t*>(cache.samples.data()),
+            reinterpret_cast<int32_t*>(nl.samples.data()),
             {n_pairs, 5},
             torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU)
         );
@@ -418,23 +423,31 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
         torch::intrusive_ptr<metatensor_torch::LabelsHolder> samples;
         {
             auto _ = MetatomicTimer("creating samples Labels (" +  std::to_string(n_pairs) + " pairs)");
-            samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
-                std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
-                samples_values,
-                metatensor::assume_unique{}
-            );
+            if (options_.check_consistency) {
+                // pairs should be unique, but I'm not 100% sure yet
+                samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+                    std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
+                    samples_values
+                );
+            } else {
+                samples = torch::make_intrusive<metatensor_torch::LabelsHolder>(
+                    std::vector<std::string>{"first_atom", "second_atom", "cell_shift_a", "cell_shift_b", "cell_shift_c"},
+                    samples_values,
+                    metatensor::assume_unique{}
+                );
+            }
         }
 
         auto distances_vectors = torch::Tensor();
         if (dtype == torch::kFloat64) {
             distances_vectors = torch::from_blob(
-                cache.distances_f64.data(),
+                nl.distances_f64.data(),
                 {n_pairs, 3, 1},
                 torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU)
             );
         } else if (dtype == torch::kFloat32) {
             distances_vectors = torch::from_blob(
-                cache.distances_f32.data(),
+                nl.distances_f32.data(),
                 {n_pairs, 3, 1},
                 torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCPU)
             );
@@ -463,7 +476,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
         }
 
         metatomic_torch::register_autograd_neighbors(system, neighbors, options_.check_consistency);
-        system->add_neighbor_list(cache.options, neighbors);
+        system->add_neighbor_list(nl.options, neighbors);
     }
 }
 

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -73,11 +73,7 @@ matrix_t inverse(matrix_t a) {
     return inverse;
 }
 
-/// Compute the inverse of the cell matrix of the system, accounting for
-/// non-periodic directions by setting the corresponding rows to an unit vector
-/// orthogonal to the periodic directions. This is used to compute the cell
-/// shifts of neighbor pairs.
-static std::array<std::array<double, 3>, 3> cell_inverse(Domain* domain) {
+std::array<std::array<double, 3>, 3> MetatomicSystemAdaptor::cell_inverse() {
     auto periodic = std::array<bool, 3>{
         static_cast<bool>(domain->xperiodic),
         static_cast<bool>(domain->yperiodic),
@@ -273,8 +269,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
     auto device = system->positions().device();
 
     double** x = atom->x;
-    auto total_n_atoms = atom->nlocal + atom->nghost;
-    auto cell_inv = cell_inverse(domain);
+    auto cell_inv = this->cell_inverse();
 
     for (auto& nl: nl_requests_) {
         {
@@ -289,14 +284,12 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
             nl.distances_f64.clear();
             for (int ii=0; ii<(list->inum + list->gnum); ii++) {
                 auto atom_i = list->ilist[ii];
-                assert(atom_i < total_n_atoms);
                 auto original_atom_i = original_atom_id_[atom_i];
                 auto i_is_original = (atom_i == original_atom_i);
 
                 auto neighbors = list->firstneigh[ii];
                 for (int jj=0; jj<list->numneigh[ii]; jj++) {
                     auto atom_j = neighbors[jj] & NEIGHMASK;
-                    assert(atom_j < total_n_atoms);
                     auto original_atom_j = original_atom_id_[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -208,6 +208,65 @@ static std::array<int32_t, 3> cell_shifts(
     return {shift_a, shift_b, shift_c};
 }
 
+void MetatomicSystemAdaptor::guess_periodic_ghosts() {
+    auto _ = MetatomicTimer("identifying periodic ghosts");
+    auto total_n_atoms = atom->nlocal + atom->nghost;
+
+    // Collect the local atom id of all local & ghosts atoms, mapping ghosts
+    // atoms which are periodic images of local atoms back to the local atoms.
+    //
+    // metatomic expects pairs corresponding to periodic atoms to be between
+    // the main atoms, but using the actual distance vector between the atom and
+    // the ghost.
+    original_atom_id_.clear();
+    original_atom_id_.reserve(total_n_atoms);
+
+    lmp_to_mta_.clear();
+    lmp_to_mta_.reserve(total_n_atoms);
+
+    mta_to_lmp.clear();
+    mta_to_lmp.reserve(total_n_atoms);
+
+    // identify all local atom by their LAMMPS atom tag.
+    local_atoms_tags_.clear();
+    for (int i=0; i<atom->nlocal; i++) {
+        original_atom_id_.emplace_back(i);
+        lmp_to_mta_.emplace_back(i);
+        mta_to_lmp.emplace_back(i);
+        local_atoms_tags_.emplace(atom->tag[i], i);
+    }
+
+    // now loop over ghosts & map them back to the main cell if needed
+    ghost_atoms_tags_.clear();
+    for (int i=atom->nlocal; i<total_n_atoms; i++) {
+        auto tag = atom->tag[i];
+        auto it = local_atoms_tags_.find(tag);
+        if (it != local_atoms_tags_.end()) {
+            // this is the periodic image of an atom already owned by this domain
+            original_atom_id_.emplace_back(it->second);
+            lmp_to_mta_.emplace_back(-1);
+        } else {
+            // this can either be a periodic image of an atom owned by another
+            // domain, or directly an atom from another domain. Since we can not
+            // really distinguish between these, we take the first atom as the
+            // "main" one and remap all atoms with the same tag to the first one
+            auto it = ghost_atoms_tags_.find(tag);
+            if (it != ghost_atoms_tags_.end()) {
+                // we already found this atom elsewhere in the system
+                original_atom_id_.emplace_back(it->second);
+                lmp_to_mta_.emplace_back(-1);
+            } else {
+                // this is the first time we are seeing this atom
+                original_atom_id_.emplace_back(i);
+                ghost_atoms_tags_.emplace(tag, i);
+
+                lmp_to_mta_.emplace_back(mta_to_lmp.size());
+                mta_to_lmp.emplace_back(i);
+            }
+        }
+    }
+}
+
 
 void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, NeighList *list) {
     auto _ = MetatomicTimer("converting neighbors list");
@@ -217,51 +276,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
     double** x = atom->x;
     auto total_n_atoms = atom->nlocal + atom->nghost;
     auto cell_inv = cell_inverse(domain);
-
-    {
-        auto _ = MetatomicTimer("identifying ghosts and real atoms");
-
-        // Collect the local atom id of all local & ghosts atoms, mapping ghosts
-        // atoms which are periodic images of local atoms back to the local atoms.
-        //
-        // metatomic expects pairs corresponding to periodic atoms to be between
-        // the main atoms, but using the actual distance vector between the atom and
-        // the ghost.
-        original_atom_id_.clear();
-        original_atom_id_.reserve(total_n_atoms);
-
-        // identify all local atom by their LAMMPS atom tag.
-        local_atoms_tags_.clear();
-        for (int i=0; i<atom->nlocal; i++) {
-            original_atom_id_.emplace_back(i);
-            local_atoms_tags_.emplace(atom->tag[i], i);
-        }
-
-        // now loop over ghosts & map them back to the main cell if needed
-        ghost_atoms_tags_.clear();
-        for (int i=atom->nlocal; i<total_n_atoms; i++) {
-            auto tag = atom->tag[i];
-            auto it = local_atoms_tags_.find(tag);
-            if (it != local_atoms_tags_.end()) {
-                // this is the periodic image of an atom already owned by this domain
-                original_atom_id_.emplace_back(it->second);
-            } else {
-                // this can either be a periodic image of an atom owned by another
-                // domain, or directly an atom from another domain. Since we can not
-                // really distinguish between these, we take the first atom as the
-                // "main" one and remap all atoms with the same tag to the first one
-                auto it = ghost_atoms_tags_.find(tag);
-                if (it != ghost_atoms_tags_.end()) {
-                    // we already found this atom elsewhere in the system
-                    original_atom_id_.emplace_back(it->second);
-                } else {
-                    // this is the first time we are seeing this atom
-                    original_atom_id_.emplace_back(i);
-                    ghost_atoms_tags_.emplace(tag, i);
-                }
-            }
-        }
-    }
 
     for (auto& cache: caches_) {
         {
@@ -364,8 +378,8 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     }
 
                     auto sample = std::array<int32_t, 5>{
-                        original_atom_i,
-                        original_atom_j,
+                        lmp_to_mta_[original_atom_i],
+                        lmp_to_mta_[original_atom_j],
                         shift[0],
                         shift[1],
                         shift[2],
@@ -472,12 +486,7 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
     auto tensor_options = torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU);
 
     // atom->x contains "real" and then ghost atoms, in that order
-    this->positions = torch::from_blob(
-        *x, {total_n_atoms, 3},
-        // requires_grad=true since we always need gradients w.r.t. positions
-        tensor_options.requires_grad(options_.requires_grad)
-    );
-    auto system_positions = this->positions.to(dtype).to(device);
+    this->positions = torch::from_blob(*x, {total_n_atoms, 3}, tensor_options);
 
     auto cell = torch::zeros({3, 3}, tensor_options);
     cell[0][0] = domain->xprd;
@@ -489,18 +498,29 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
     cell[2][1] = domain->yz;
     cell[2][2] = domain->zprd;
 
-    cell = cell.to(dtype).to(device);
-
     // Periodic boundary conditions handling.
     auto pbc = torch::tensor(
         {domain->xperiodic, domain->yperiodic, domain->zperiodic},
-        torch::TensorOptions().dtype(torch::kBool).device(device)
+        torch::TensorOptions().dtype(torch::kBool).device(torch::kCPU)
     );
 
-    cell.index_put_(
-        {torch::logical_not(pbc)},
-        torch::tensor({0.0}, torch::TensorOptions().dtype(dtype).device(device))
+    cell.index_put_({torch::logical_not(pbc)}, torch::tensor({0.0}, tensor_options));
+
+    this->guess_periodic_ghosts();
+
+    // Only keep the atoms which are not periodic images of other atoms
+    auto mta_to_lmp_tensor = torch::from_blob(
+        mta_to_lmp.data(),
+        {static_cast<int64_t>(mta_to_lmp.size())},
+        torch::TensorOptions().dtype(torch::kInt).device(torch::kCPU)
     );
+    this->atomic_types_ = this->atomic_types_.index_select(0, mta_to_lmp_tensor);
+    this->positions = this->positions.index_select(0, mta_to_lmp_tensor);
+
+    this->positions.set_requires_grad(options_.requires_grad);
+
+    auto system_positions = this->positions.to(dtype).to(device);
+    cell = cell.to(dtype).to(device);
 
     if (do_virial) {
         auto model_strain = this->strain.to(dtype).to(device);
@@ -515,7 +535,7 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
         atomic_types_.to(device),
         system_positions,
         cell,
-        pbc
+        pbc.to(device)
     );
 
     this->setup_neighbors(system, list);

--- a/src/ML-METATOMIC/metatomic_system.h
+++ b/src/ML-METATOMIC/metatomic_system.h
@@ -16,7 +16,6 @@
 
 #include <vector>
 #include <array>
-#include <unordered_set>
 
 #include "pointers.h"
 #include "pair.h"
@@ -44,22 +43,6 @@ struct MetatomicNeighborsData {
     // single neighbors sample containing [i, j, S_a, S_b, S_c]
     using sample_t = std::array<int32_t, 5>;
 
-    struct SampleHasher {
-        static void hash_combine(std::size_t& seed, const int32_t& v) {
-            seed ^= std::hash<int32_t>()(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-        }
-
-        size_t operator()(const sample_t& s) const {
-            size_t hash = 0;
-            hash_combine(hash, s[0]);
-            hash_combine(hash, s[1]);
-            hash_combine(hash, s[2]);
-            hash_combine(hash, s[3]);
-            hash_combine(hash, s[4]);
-            return hash;
-        }
-    };
-
     // cutoff for this NL in LAMMPS units
     double cutoff;
     // options of the NL as requested by the model
@@ -68,10 +51,6 @@ struct MetatomicNeighborsData {
     // Below are cached allocations for the LAMMPS -> metatomic NL translation
     // TODO: report memory usage for these?
 
-    // we keep the set of samples twice: once in `known_samples` to remove
-    // duplicated pairs, and once in `samples` in a format that can be
-    // used to create a torch::Tensor.
-    std::unordered_set<sample_t, SampleHasher> known_samples;
     std::vector<sample_t> samples;
     // pairs distances vectors
     std::vector<std::array<double, 3>> distances_f64;
@@ -116,7 +95,7 @@ public:
     MetatomicSystemOptions options_;
 
     // allocations caches for all the NL requested by the model
-    std::vector<MetatomicNeighborsData> caches_;
+    std::vector<MetatomicNeighborsData> nl_requests_;
     // allocation cache for the atomic types in the system
     torch::Tensor atomic_types_;
 

--- a/src/ML-METATOMIC/metatomic_system.h
+++ b/src/ML-METATOMIC/metatomic_system.h
@@ -63,7 +63,9 @@ public:
 
     virtual ~MetatomicSystemAdaptor();
 
-    void add_nl_request(double cutoff, metatomic_torch::NeighborListOptions request);
+    virtual void add_nl_request(
+        double cutoff, metatomic_torch::NeighborListOptions request
+    );
 
     // Create a metatomic system matching the LAMMPS system data
     virtual metatomic_torch::System system_from_lmp(
@@ -90,6 +92,12 @@ public:
     // Some ghosts atoms correspond to periodic images of other atoms, we need
     // to identify them to avoid duplicated pairs in the neighbor lists.
     void guess_periodic_ghosts();
+
+    /// Compute the inverse of the cell matrix of the system, accounting for
+    /// non-periodic directions by setting the corresponding rows to an unit vector
+    /// orthogonal to the periodic directions. This is used to compute the cell
+    /// shifts of neighbor pairs.
+    std::array<std::array<double, 3>, 3> cell_inverse();
 
     // options for this system adaptor
     MetatomicSystemOptions options_;

--- a/src/ML-METATOMIC/metatomic_system.h
+++ b/src/ML-METATOMIC/metatomic_system.h
@@ -101,9 +101,16 @@ public:
     // conversion) to access its gradient
     torch::Tensor positions;
 
+    // LAMMPS atom id for all atoms in the metatomic system.
+    std::vector<int> mta_to_lmp;
+
  protected:
-    // setup the metatomic neighbors list from the internal LAMMPS one,
+    // setup the metatomic neighbors lists from the internal LAMMPS one,
     void setup_neighbors(metatomic_torch::System& system, NeighList* list);
+
+    // Some ghosts atoms correspond to periodic images of other atoms, we need
+    // to identify them to avoid duplicated pairs in the neighbor lists.
+    void guess_periodic_ghosts();
 
     // options for this system adaptor
     MetatomicSystemOptions options_;
@@ -112,13 +119,19 @@ public:
     std::vector<MetatomicNeighborsData> caches_;
     // allocation cache for the atomic types in the system
     torch::Tensor atomic_types_;
-    // allocation cache holding the "original atom" id for all atoms in the
-    // system. This is the same as the atom id for all local atoms. For ghost
-    // atoms, this is either the id of the corresponding local atom if the ghost
-    // is a periodic image of a local atom, the id of the first ghost we found
-    // with a given atom tag if the ghost is a periodic image of another ghost;
-    // or the id of the ghost in all other cases.
+
+    // Original atom id for all atoms in the LAMMPS system.
+    //
+    // This is the same as the atom id for all local atoms. For ghost atoms,
+    // this is either the id of the corresponding local atom if the ghost is a
+    // periodic image of a local atom, the id of the first ghost we found with a
+    // given atom tag if the ghost is a periodic image of another ghost; or the
+    // id of the ghost in all other cases.
     std::vector<int> original_atom_id_;
+    // Metatomic atom id for all atoms in the LAMMPS system.
+    // Contains `atoms->nlocal + atoms->nghost` elements
+    std::vector<int> lmp_to_mta_;
+
     // allocation cache holding the map from atom tag to atom id for local
     // atoms.
     std::unordered_map<tagint, int> local_atoms_tags_;

--- a/src/ML-METATOMIC/pair_metatomic.cpp
+++ b/src/ML-METATOMIC/pair_metatomic.cpp
@@ -817,8 +817,6 @@ void PairMetatomic::compute(int eflag, int vflag) {
     }
 }
 
-void PairMetatomic::pre_compute() {}
-
 void PairMetatomic::store_forces(const at::Tensor& forces_tensor) {
     assert(forces_tensor.is_cpu() && forces_tensor.scalar_type() == torch::kFloat64);
 

--- a/src/ML-METATOMIC/pair_metatomic.cpp
+++ b/src/ML-METATOMIC/pair_metatomic.cpp
@@ -593,7 +593,6 @@ void PairMetatomic::compute(int eflag, int vflag) {
             }
             mta_data->energy_output->per_atom = true;
         } else {
-            assert(eflag_global);
             mta_data->energy_output->per_atom = false;
         }
 
@@ -764,11 +763,12 @@ void PairMetatomic::compute(int eflag, int vflag) {
                 assert(samples_values.sizes() == mta_data->selected_atoms_values.sizes());
 
                 auto energies = energy_detached.accessor<double, 2>();
+                const auto& mta_to_lmp = this->system_adaptor->mta_to_lmp;
                 for (int64_t i=0; i<energy_samples->count(); i++) {
                     assert(samples[i][0] == 0);
                     // handle potentially out of order samples in
                     // the per-atom energy tensor
-                    auto atom_i = samples[i][1];
+                    auto atom_i = mta_to_lmp[samples[i][1]];
                     assert(atom_i < atom->nlocal + atom->nghost);
                     eatom[atom_i] += this->scale * energies[i][0];
                 }
@@ -822,17 +822,20 @@ void PairMetatomic::pre_compute() {}
 void PairMetatomic::store_forces(const at::Tensor& forces_tensor) {
     assert(forces_tensor.is_cpu() && forces_tensor.scalar_type() == torch::kFloat64);
 
-    int num_forces_to_update;
-    if (mta_data->non_conservative) {
-        num_forces_to_update = atom->nlocal;
-    } else {
-        num_forces_to_update = atom->nlocal + atom->nghost;
-    }
-
     auto forces = forces_tensor.accessor<double, 2>();
-    for (int i=0; i<num_forces_to_update; i++) {
+    for (int i=0; i<atom->nlocal; i++) {
         atom->f[i][0] += this->scale * forces[i][0];
         atom->f[i][1] += this->scale * forces[i][1];
         atom->f[i][2] += this->scale * forces[i][2];
+    }
+
+    // in non-conservative mode we do not need to update forces on ghost atoms
+    if (!mta_data->non_conservative) {
+        const auto& mta_to_lmp = this->system_adaptor->mta_to_lmp;
+        for (int i=atom->nlocal; i<forces.size(0); i++) {
+            atom->f[mta_to_lmp[i]][0] += this->scale * forces[i][0];
+            atom->f[mta_to_lmp[i]][1] += this->scale * forces[i][1];
+            atom->f[mta_to_lmp[i]][2] += this->scale * forces[i][2];
+        }
     }
 }

--- a/src/ML-METATOMIC/pair_metatomic.h
+++ b/src/ML-METATOMIC/pair_metatomic.h
@@ -65,9 +65,6 @@ public:
     // store the forces from the model in LAMMPS data structures
     virtual void store_forces(const at::Tensor& forces_tensor);
 
-    // called one at the beginning of `compute`
-    virtual void pre_compute();
-
 protected:
     // get the set of devices both available on the current machine and supported
     // by the model


### PR DESCRIPTION
This PR brings a couple of improvements around `System`:

-  first we remove periodic images of other atoms from the System, making it a lot smaller. For many ML models, it is faster to do this preprocessing because it then means the ML model has less work to do
- second we skip more pairs during the NL filtering, removing the need for inserting every single sample in a `set`. I'm not 100% sure this will always produce unique samples, so we also check for uniqueness when `check_consistency = on`.
- Finally, removing the need for a `set` means we can now more easily process the NL with pure kokkos code instead of needing some torch operations. This is marginally faster, but will enable using lammps-kokkos with non-torch models down the line.