### PR TITLE
Fix the `guess_periodic_ghosts` for non-deterministic Kokkos NL builds 

### DIFF
--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -489,39 +489,12 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
         torch::tensor({0.0}, tensor_options)
     );
 
-    // make sure to sync the updated tags to host
-    atomKK->sync(ExecutionSpaceFromDevice<LMPHostType>::space, TAG_MASK);
+    // Sync tags and positions to host. Tags are needed by
+    // guess_periodic_ghosts() to build the tag->index maps. Positions are
+    // needed because domain->inside(atom->x[i]) is called on the host to
+    // identify the direct inter-domain ghost vs periodic images.
+    atomKK->sync(ExecutionSpaceFromDevice<LMPHostType>::space, TAG_MASK | X_MASK);
     this->guess_periodic_ghosts();
-
-    {
-        static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
-        if (debug_nl) {
-            int n_map_minus1 = 0;
-            int n_atoms_original = 0;
-            for (int i = 0; i < atomKK->nlocal + atomKK->nghost; i++) {
-                int mapped = atom->map(atom->tag[i]);
-                if (mapped == -1) {
-                    n_map_minus1++;
-                    if (n_map_minus1 <= 5) {
-                        fprintf(stderr, "[rank %d] atom->map returned -1 for i=%d tag=%lld (ghost=%s)\n",
-                            comm->me, i, (long long)atom->tag[i], i >= atomKK->nlocal ? "yes" : "no");
-                    }
-                }
-                if (original_atom_id_[i] == i) n_atoms_original++;
-            }
-            fprintf(stderr, "\nmetatomic-kk-map-debug [rank %d]: n_map_minus1=%d n_atoms_original=%d mta_to_lmp_size=%zu\n",
-                comm->me, n_map_minus1, n_atoms_original, mta_to_lmp.size());
-        }
-
-        if (debug_nl) {
-            int64_t checksum = 0;
-            for (int i = 0; i < atomKK->nlocal + atomKK->nghost; i++) {
-                checksum += (int64_t)original_atom_id_[i] * (i + 1);
-            }
-            fprintf(stderr, "\nmetatomic-kk-map-debug [rank %d]: checksum=%lld\n",
-                comm->me, (long long)checksum);
-        }
-    }
 
     this->mta_to_lmp_tensor = torch::from_blob(
         mta_to_lmp.data(),

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -501,6 +501,18 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
     // make sure to sync the updated tags to host
     atomKK->sync(ExecutionSpaceFromDevice<LMPHostType>::space, TAG_MASK);
     this->guess_periodic_ghosts();
+
+    {
+        static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+        if (debug_nl) {
+            int n_atoms_original = 0;
+            for (size_t i = 0; i < original_atom_id_.size(); i++) {
+                if (original_atom_id_[i] == static_cast<int>(i)) n_atoms_original++;
+            }
+            fprintf(stderr, "metatomic-kk-ghost-debug [rank %d]: total_atoms=%zu n_atoms_original=%d mta_to_lmp_size=%zu\n",
+                comm->me, original_atom_id_.size(), n_atoms_original, mta_to_lmp.size());
+        }
+    }
     this->mta_to_lmp_tensor = torch::from_blob(
         mta_to_lmp.data(),
         {static_cast<int64_t>(mta_to_lmp.size())},

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -27,6 +27,8 @@
 #include "error.h"
 
 #include <torch/cuda.h>
+#include <cstdio>
+#include <cstdlib>
 
 using namespace LAMMPS_NS;
 
@@ -77,29 +79,52 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::add_nl_request(double cutoff, met
     });
 }
 
+KOKKOS_INLINE_FUNCTION
+Kokkos::Array<int32_t, 3> cell_shifts(
+    Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>& cell_inv,
+    const double pair_shift[3]
+) {
+    auto shift_a = static_cast<int32_t>(std::round(
+            cell_inv(0, 0) * pair_shift[0] +
+            cell_inv(0, 1) * pair_shift[1] +
+            cell_inv(0, 2) * pair_shift[2]
+    ));
+    auto shift_b = static_cast<int32_t>(std::round(
+        cell_inv(1, 0) * pair_shift[0] +
+        cell_inv(1, 1) * pair_shift[1] +
+        cell_inv(1, 2) * pair_shift[2]
+    ));
+    auto shift_c = static_cast<int32_t>(std::round(
+        cell_inv(2, 0) * pair_shift[0] +
+        cell_inv(2, 1) * pair_shift[1] +
+        cell_inv(2, 2) * pair_shift[2]
+    )); 
+    return {shift_a, shift_b, shift_c};
+}
+
+
 
 template<class DeviceType>
 void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torch::System& system, NeighListKokkos<DeviceType>* list) {
     auto _ = MetatomicTimer("converting kokkos neighbors list");
 
+    static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+
     auto dtype = system->positions().scalar_type();
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
     auto max_number_of_neighbors = list->maxneighs;
 
-    auto original_id = UnmanagedView<int*, LMPHostType>(
-        original_atom_id_.data(),
-        original_atom_id_.size()
+    auto d_original_atom_id = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", original_atom_id_.size());
+    Kokkos::deep_copy(
+        d_original_atom_id, 
+        UnmanagedView<int*, LMPHostType>(original_atom_id_.data(), original_atom_id_.size())
     );
-    auto d_original_id = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", original_atom_id_.size());
-    Kokkos::deep_copy(d_original_id, original_id);
 
-    auto lmp_to_mta = UnmanagedView<int*, LMPHostType>(
-        lmp_to_mta_.data(),
-        lmp_to_mta_.size()
-    );
     auto d_lmp_to_mta = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", lmp_to_mta_.size());
-    Kokkos::deep_copy(d_lmp_to_mta, lmp_to_mta);
-
+    Kokkos::deep_copy(
+        d_lmp_to_mta, 
+        UnmanagedView<int*, LMPHostType>(lmp_to_mta_.data(), lmp_to_mta_.size())
+    );
 
     auto cell_inv = this->cell_inverse();
     auto d_cell_inv = Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>("cell_inv", 3, 3);
@@ -109,28 +134,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
     );
 
     auto x = atomKK->k_x.view<DeviceType>();
-    auto cell_shifts = KOKKOS_LAMBDA(
-        const Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>& cell_inv,
-        const double pair_shift[3],
-        int32_t shift_out[3]
-    ) {
-        shift_out[0] = static_cast<int32_t>(std::round(
-            cell_inv(0, 0) * pair_shift[0] +
-            cell_inv(0, 1) * pair_shift[1] +
-            cell_inv(0, 2) * pair_shift[2]
-        ));
-        shift_out[1] = static_cast<int32_t>(std::round(
-            cell_inv(1, 0) * pair_shift[0] +
-            cell_inv(1, 1) * pair_shift[1] +
-            cell_inv(1, 2) * pair_shift[2]
-        ));
-        shift_out[2] = static_cast<int32_t>(std::round(
-            cell_inv(2, 0) * pair_shift[0] +
-            cell_inv(2, 1) * pair_shift[1] +
-            cell_inv(2, 2) * pair_shift[2]
-        ));
-    };
-
     for (auto& nl: nl_requests_kk_) {
         auto cutoff2 = nl.cutoff * nl.cutoff;
         auto full_list = nl.options->full_list();
@@ -160,6 +163,9 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         Kokkos::deep_copy(h_processed_all_pairs, false);
         processed_all_pairs.template modify<LMPHostType>();
         processed_all_pairs.template sync<LMPDeviceType>();
+
+        auto d_stats = Kokkos::View<int64_t*, LMPDeviceType>("nl_stats", 8);
+        int retries = 0;
 
         while (!h_processed_all_pairs()) {
             {
@@ -192,6 +198,10 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             processed_all_pairs.template modify<LMPHostType>();
             processed_all_pairs.template sync<LMPDeviceType>();
 
+            if (debug_nl) {
+                Kokkos::deep_copy(d_stats, 0);
+            }
+
             auto d_numneigh = list->d_numneigh;
             auto d_ilist = list->d_ilist;
             auto d_neighbors = list->d_neighbors;
@@ -205,26 +215,31 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (jj >= d_numneigh[ii]) {
                         return;
                     }
+                    if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(0), int64_t(1));
+
                     auto atom_i = d_ilist[ii];
-                    auto original_atom_i = d_original_id[atom_i];
+                    auto original_atom_i = d_original_atom_id[atom_i];
                     auto i_is_original = (atom_i == original_atom_i);
                     auto atom_j = d_neighbors(ii, jj) & NEIGHMASK;
-                    auto original_atom_j = d_original_id[atom_j];
+                    auto original_atom_j = d_original_atom_id[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
+                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(1), int64_t(1));
                         return;
                     }
 
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
+                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(2), int64_t(1));
                         return;
                     }
 
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
+                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(3), int64_t(1));
                         return;
                     }
 
@@ -242,6 +257,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
+                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(4), int64_t(1));
                         return;
                     }
 
@@ -261,10 +277,9 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                         shift_j[1] - shift_i[1],
                         shift_j[2] - shift_i[2],
                     };
-
-                    int32_t shift[3] = {0, 0, 0};
+                    Kokkos::Array<int32_t, 3> shift = {0, 0, 0};
                     if (pair_shift[0] != 0 || pair_shift[1] != 0 || pair_shift[2] != 0) {
-                        cell_shifts(d_cell_inv, pair_shift, shift);
+                        shift = cell_shifts(d_cell_inv, pair_shift);
 
                         if (!full_list && original_atom_i == original_atom_j) {
                             // If a half neighbors list has been requested, do
@@ -276,6 +291,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
+                                if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(5), int64_t(1));
                                 return;
                             }
 
@@ -295,6 +311,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                                 //  X X X │ X X X
                                 //  X X X │ X X X
                                 //  X X X │ X X X
+                                if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(5), int64_t(1));
                                 return;
                             }
                         }
@@ -304,8 +321,10 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (pair_i >= nl.samples.extent(0)) {
                         // stop and re-allocate larger arrays
                         d_processed_all_pairs() = false;
+                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(7), int64_t(1));
                         return;
                     }
+                    if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(6), int64_t(1));
 
                     nl.samples(pair_i, 0) = d_lmp_to_mta[original_atom_i];
                     nl.samples(pair_i, 1) = d_lmp_to_mta[original_atom_j];
@@ -329,7 +348,25 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             processed_all_pairs.template sync<LMPHostType>();
             if (!h_processed_all_pairs()) {
                 pairs_capacity *= 2;
+                retries++;
             }
+        }
+
+        if (debug_nl) {
+            auto h_stats = Kokkos::View<int64_t*, Kokkos::LayoutRight, LMPHostType>("h_nl_stats", 8);
+            Kokkos::deep_copy(h_stats, d_stats);
+            fprintf(stderr,
+                "metatomic-kk-nl-debug [rank %d] NL debug (cutoff=%.4f, full_list=%s):\n"
+                "  nlocal=%d nghost=%d inum=%d gnum=%d maxneighs=%d\n"
+                "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
+                "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
+                "  written=%lld overflow=%lld retries=%d buffer_capacity=%zu\n",
+                comm->me, nl.cutoff, full_list ? "true" : "false",
+                atomKK->nlocal, atomKK->nghost, list->inum, list->gnum, list->maxneighs,
+                (long long)h_stats(0), (long long)h_stats(1), (long long)h_stats(2),
+                (long long)h_stats(3), (long long)h_stats(4), (long long)h_stats(5),
+                (long long)h_stats(6), (long long)h_stats(7), retries, pairs_capacity
+            );
         }
 
         n_pairs.template modify<LMPDeviceType>();

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -135,13 +135,13 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         auto full_list = nl.options->full_list();
 
         auto cutoff_ratio = nl.cutoff / options_.interaction_range;
-        uint64_t max_n_pairs = (uint64_t) total_n_atoms * list->maxneighs;
+        size_t max_n_pairs = static_cast<size_t>(total_n_atoms) * list->maxneighs;
         // Allocate for a much smaller number of pairs to avoid wasting memory
         // (especially when the interaction range is much larger than the NL
         // cutoff)
         auto pairs_capacity = std::max(
             std::max(
-                static_cast<uint64_t>(max_n_pairs * cutoff_ratio / 1000),
+                static_cast<size_t>(max_n_pairs * cutoff_ratio / 1000),
                 100ul
             ),
             nl.samples.extent(0)

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -509,8 +509,17 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
                 }
                 if (original_atom_id_[i] == i) n_atoms_original++;
             }
-            fprintf(stderr, "metatomic-kk-map-debug [rank %d]: n_map_minus1=%d n_atoms_original=%d mta_to_lmp_size=%zu\n",
+            fprintf(stderr, "\nmetatomic-kk-map-debug [rank %d]: n_map_minus1=%d n_atoms_original=%d mta_to_lmp_size=%zu\n",
                 comm->me, n_map_minus1, n_atoms_original, mta_to_lmp.size());
+        }
+
+        if (debug_nl) {
+            int64_t checksum = 0;
+            for (int i = 0; i < atomKK->nlocal + atomKK->nghost; i++) {
+                checksum += (int64_t)original_atom_id_[i] * (i + 1);
+            }
+            fprintf(stderr, "\nmetatomic-kk-map-debug [rank %d]: checksum=%lld\n",
+                comm->me, (long long)checksum);
         }
     }
 

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -81,7 +81,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::add_nl_request(double cutoff, met
 
 KOKKOS_INLINE_FUNCTION
 Kokkos::Array<int32_t, 3> cell_shifts(
-    Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>& cell_inv,
+    const Kokkos::View<double**, Kokkos::LayoutRight, LMPDeviceType>& cell_inv,
     const double pair_shift[3]
 ) {
     auto shift_a = static_cast<int32_t>(std::round(

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -108,7 +108,8 @@ template<class DeviceType>
 void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torch::System& system, NeighListKokkos<DeviceType>* list) {
     auto _ = MetatomicTimer("converting kokkos neighbors list");
 
-    static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+    static bool debug_nl_static = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+    bool debug_nl = debug_nl_static;
 
     auto dtype = system->positions().scalar_type();
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -27,8 +27,6 @@
 #include "error.h"
 
 #include <torch/cuda.h>
-#include <cstdio>
-#include <cstdlib>
 
 using namespace LAMMPS_NS;
 
@@ -108,22 +106,19 @@ template<class DeviceType>
 void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torch::System& system, NeighListKokkos<DeviceType>* list) {
     auto _ = MetatomicTimer("converting kokkos neighbors list");
 
-    static bool debug_nl_static = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
-    bool debug_nl = debug_nl_static;
-
     auto dtype = system->positions().scalar_type();
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
     auto max_number_of_neighbors = list->maxneighs;
 
     auto d_original_atom_id = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", original_atom_id_.size());
     Kokkos::deep_copy(
-        d_original_atom_id, 
+        d_original_atom_id,
         UnmanagedView<int*, LMPHostType>(original_atom_id_.data(), original_atom_id_.size())
     );
 
     auto d_lmp_to_mta = Kokkos::View<int*, Kokkos::LayoutRight, LMPDeviceType>("", lmp_to_mta_.size());
     Kokkos::deep_copy(
-        d_lmp_to_mta, 
+        d_lmp_to_mta,
         UnmanagedView<int*, LMPHostType>(lmp_to_mta_.data(), lmp_to_mta_.size())
     );
 
@@ -165,9 +160,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         processed_all_pairs.template modify<LMPHostType>();
         processed_all_pairs.template sync<LMPDeviceType>();
 
-        auto d_stats = Kokkos::View<int64_t*, LMPDeviceType>("nl_stats", 12);
-        int retries = 0;
-
         while (!h_processed_all_pairs()) {
             {
                 auto _ = MetatomicTimer("allocating caches for kokkos neighbors list (capacity for " + std::to_string(pairs_capacity) + " pairs)");
@@ -199,10 +191,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             processed_all_pairs.template modify<LMPHostType>();
             processed_all_pairs.template sync<LMPDeviceType>();
 
-            if (debug_nl) {
-                Kokkos::deep_copy(d_stats, 0);
-            }
-
             auto d_numneigh = list->d_numneigh;
             auto d_ilist = list->d_ilist;
             auto d_neighbors = list->d_neighbors;
@@ -217,9 +205,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (jj >= d_numneigh[atom_i]) {
                         return;
                     }
-                    if (debug_nl) {
-                        Kokkos::atomic_fetch_add(&d_stats(0), int64_t(1));
-                    }
 
                     auto original_atom_i = d_original_atom_id[atom_i];
                     auto i_is_original = (atom_i == original_atom_i);
@@ -229,20 +214,17 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
-                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(1), int64_t(1));
                         return;
                     }
 
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
-                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(2), int64_t(1));
                         return;
                     }
 
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
-                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(3), int64_t(1));
                         return;
                     }
 
@@ -260,7 +242,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
-                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(4), int64_t(1));
                         return;
                     }
 
@@ -294,7 +275,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
-                                if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(5), int64_t(1));
                                 return;
                             }
 
@@ -314,7 +294,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                                 //  X X X │ X X X
                                 //  X X X │ X X X
                                 //  X X X │ X X X
-                                if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(5), int64_t(1));
                                 return;
                             }
                         }
@@ -324,10 +303,8 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (pair_i >= nl.samples.extent(0)) {
                         // stop and re-allocate larger arrays
                         d_processed_all_pairs() = false;
-                        if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(7), int64_t(1));
                         return;
                     }
-                    if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(6), int64_t(1));
 
                     nl.samples(pair_i, 0) = d_lmp_to_mta[original_atom_i];
                     nl.samples(pair_i, 1) = d_lmp_to_mta[original_atom_j];
@@ -351,25 +328,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             processed_all_pairs.template sync<LMPHostType>();
             if (!h_processed_all_pairs()) {
                 pairs_capacity *= 2;
-                retries++;
             }
-        }
-
-        if (debug_nl) {
-            auto h_stats = Kokkos::View<int64_t*, Kokkos::LayoutRight, LMPHostType>("h_nl_stats", 12);
-            Kokkos::deep_copy(h_stats, d_stats);
-            fprintf(stderr,
-                "\nmetatomic-kk-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
-                "  nlocal=%d nghost=%d inum=%d gnum=%d maxneighs=%d\n"
-                "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
-                "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
-                "  written=%lld overflow=%lld retries=%d buffer_capacity=%zu\n",
-                comm->me, nl.cutoff, full_list ? "true" : "false",
-                atomKK->nlocal, atomKK->nghost, list->inum, list->gnum, list->maxneighs,
-                (long long)h_stats(0), (long long)h_stats(1), (long long)h_stats(2),
-                (long long)h_stats(3), (long long)h_stats(4), (long long)h_stats(5),
-                (long long)h_stats(6), (long long)h_stats(7), retries, pairs_capacity
-            );
         }
 
         n_pairs.template modify<LMPDeviceType>();

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -443,6 +443,13 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
     auto _ = MetatomicTimer("creating System from LAMMPS-kokkos data");
     assert(device == this->device_);
 
+    // Sync atom data to the device execution space. Positions (X_MASK) and
+    // types (TYPE_MASK) are read on-device by the neighbor list kernel and
+    // type mapping. Tags (TAG_MASK) are read on the host by
+    // guess_periodic_ghosts(). Without these syncs, device-side views may
+    // contain stale data from a previous timestep.
+    atomKK->sync(ExecutionSpaceFromDevice<DeviceType>::space, X_MASK | TYPE_MASK);
+
     auto total_n_atoms = atomKK->nlocal + atomKK->nghost;
 
     atomic_types_.resize_({total_n_atoms});

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -165,7 +165,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         processed_all_pairs.template modify<LMPHostType>();
         processed_all_pairs.template sync<LMPDeviceType>();
 
-        auto d_stats = Kokkos::View<int64_t*, LMPDeviceType>("nl_stats", 8);
+        auto d_stats = Kokkos::View<int64_t*, LMPDeviceType>("nl_stats", 12);
         int retries = 0;
 
         while (!h_processed_all_pairs()) {
@@ -217,13 +217,22 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     if (jj >= d_numneigh[atom_i]) {
                         return;
                     }
-                    if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(0), int64_t(1));
+                    if (debug_nl) {
+                        Kokkos::atomic_fetch_add(&d_stats(0), int64_t(1));
+                    }
 
                     auto original_atom_i = d_original_atom_id[atom_i];
                     auto i_is_original = (atom_i == original_atom_i);
                     auto atom_j = d_neighbors(atom_i, jj) & NEIGHMASK;
                     auto original_atom_j = d_original_atom_id[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
+
+                    if (debug_nl) {
+                        Kokkos::atomic_fetch_add(&d_stats(8), int64_t(atom_i));
+                        Kokkos::atomic_fetch_add(&d_stats(9), int64_t(atom_j));
+                        if (i_is_original) Kokkos::atomic_fetch_add(&d_stats(10), int64_t(1));
+                        if (j_is_original) Kokkos::atomic_fetch_add(&d_stats(11), int64_t(1));
+                    }
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
@@ -354,19 +363,21 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         }
 
         if (debug_nl) {
-            auto h_stats = Kokkos::View<int64_t*, Kokkos::LayoutRight, LMPHostType>("h_nl_stats", 8);
+            auto h_stats = Kokkos::View<int64_t*, Kokkos::LayoutRight, LMPHostType>("h_nl_stats", 12);
             Kokkos::deep_copy(h_stats, d_stats);
             fprintf(stderr,
                 "metatomic-kk-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
                 "  nlocal=%d nghost=%d inum=%d gnum=%d maxneighs=%d\n"
                 "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
                 "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
-                "  written=%lld overflow=%lld retries=%d buffer_capacity=%zu\n",
+                "  written=%lld overflow=%lld retries=%d buffer_capacity=%zu\n"
+                "  sum_i=%lld sum_j=%lld n_i_original=%lld n_j_original=%lld\n",
                 comm->me, nl.cutoff, full_list ? "true" : "false",
                 atomKK->nlocal, atomKK->nghost, list->inum, list->gnum, list->maxneighs,
                 (long long)h_stats(0), (long long)h_stats(1), (long long)h_stats(2),
                 (long long)h_stats(3), (long long)h_stats(4), (long long)h_stats(5),
-                (long long)h_stats(6), (long long)h_stats(7), retries, pairs_capacity
+                (long long)h_stats(6), (long long)h_stats(7), retries, pairs_capacity,
+                (long long)h_stats(8), (long long)h_stats(9), (long long)h_stats(10), (long long)h_stats(11)
             );
         }
 

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -496,14 +496,24 @@ metatomic_torch::System MetatomicSystemAdaptorKokkos<DeviceType>::system_from_lm
     {
         static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
         if (debug_nl) {
+            int n_map_minus1 = 0;
             int n_atoms_original = 0;
-            for (size_t i = 0; i < original_atom_id_.size(); i++) {
-                if (original_atom_id_[i] == static_cast<int>(i)) n_atoms_original++;
+            for (int i = 0; i < atomKK->nlocal + atomKK->nghost; i++) {
+                int mapped = atom->map(atom->tag[i]);
+                if (mapped == -1) {
+                    n_map_minus1++;
+                    if (n_map_minus1 <= 5) {
+                        fprintf(stderr, "[rank %d] atom->map returned -1 for i=%d tag=%lld (ghost=%s)\n",
+                            comm->me, i, (long long)atom->tag[i], i >= atomKK->nlocal ? "yes" : "no");
+                    }
+                }
+                if (original_atom_id_[i] == i) n_atoms_original++;
             }
-            fprintf(stderr, "metatomic-kk-ghost-debug [rank %d]: total_atoms=%zu n_atoms_original=%d mta_to_lmp_size=%zu\n",
-                comm->me, original_atom_id_.size(), n_atoms_original, mta_to_lmp.size());
+            fprintf(stderr, "metatomic-kk-map-debug [rank %d]: n_map_minus1=%d n_atoms_original=%d mta_to_lmp_size=%zu\n",
+                comm->me, n_map_minus1, n_atoms_original, mta_to_lmp.size());
         }
     }
+
     this->mta_to_lmp_tensor = torch::from_blob(
         mta_to_lmp.data(),
         {static_cast<int64_t>(mta_to_lmp.size())},

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -227,13 +227,6 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     auto original_atom_j = d_original_atom_id[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 
-                    if (debug_nl) {
-                        Kokkos::atomic_fetch_add(&d_stats(8), int64_t(atom_i));
-                        Kokkos::atomic_fetch_add(&d_stats(9), int64_t(atom_j));
-                        if (i_is_original) Kokkos::atomic_fetch_add(&d_stats(10), int64_t(1));
-                        if (j_is_original) Kokkos::atomic_fetch_add(&d_stats(11), int64_t(1));
-                    }
-
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
                         if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(1), int64_t(1));
@@ -366,18 +359,16 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             auto h_stats = Kokkos::View<int64_t*, Kokkos::LayoutRight, LMPHostType>("h_nl_stats", 12);
             Kokkos::deep_copy(h_stats, d_stats);
             fprintf(stderr,
-                "metatomic-kk-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
+                "\nmetatomic-kk-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
                 "  nlocal=%d nghost=%d inum=%d gnum=%d maxneighs=%d\n"
                 "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
                 "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
-                "  written=%lld overflow=%lld retries=%d buffer_capacity=%zu\n"
-                "  sum_i=%lld sum_j=%lld n_i_original=%lld n_j_original=%lld\n",
+                "  written=%lld overflow=%lld retries=%d buffer_capacity=%zu\n",
                 comm->me, nl.cutoff, full_list ? "true" : "false",
                 atomKK->nlocal, atomKK->nghost, list->inum, list->gnum, list->maxneighs,
                 (long long)h_stats(0), (long long)h_stats(1), (long long)h_stats(2),
                 (long long)h_stats(3), (long long)h_stats(4), (long long)h_stats(5),
-                (long long)h_stats(6), (long long)h_stats(7), retries, pairs_capacity,
-                (long long)h_stats(8), (long long)h_stats(9), (long long)h_stats(10), (long long)h_stats(11)
+                (long long)h_stats(6), (long long)h_stats(7), retries, pairs_capacity
             );
         }
 

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -213,15 +213,15 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
                     {list->inum + list->gnum, max_number_of_neighbors}
                 ),
                 KOKKOS_LAMBDA(size_t ii, size_t jj) {
-                    if (jj >= d_numneigh[ii]) {
+                    auto atom_i = d_ilist[ii];
+                    if (jj >= d_numneigh[atom_i]) {
                         return;
                     }
                     if (debug_nl) Kokkos::atomic_fetch_add(&d_stats(0), int64_t(1));
 
-                    auto atom_i = d_ilist[ii];
                     auto original_atom_i = d_original_atom_id[atom_i];
                     auto i_is_original = (atom_i == original_atom_i);
-                    auto atom_j = d_neighbors(ii, jj) & NEIGHMASK;
+                    auto atom_j = d_neighbors(atom_i, jj) & NEIGHMASK;
                     auto original_atom_j = d_original_atom_id[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 
@@ -357,7 +357,7 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
             auto h_stats = Kokkos::View<int64_t*, Kokkos::LayoutRight, LMPHostType>("h_nl_stats", 8);
             Kokkos::deep_copy(h_stats, d_stats);
             fprintf(stderr,
-                "metatomic-kk-nl-debug [rank %d] NL debug (cutoff=%.4f, full_list=%s):\n"
+                "metatomic-kk-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
                 "  nlocal=%d nghost=%d inum=%d gnum=%d maxneighs=%d\n"
                 "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
                 "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"

--- a/src/KOKKOS/metatomic_system_kokkos.cpp
+++ b/src/KOKKOS/metatomic_system_kokkos.cpp
@@ -140,13 +140,13 @@ void MetatomicSystemAdaptorKokkos<DeviceType>::setup_neighbors_kk(metatomic_torc
         auto full_list = nl.options->full_list();
 
         auto cutoff_ratio = nl.cutoff / options_.interaction_range;
-        size_t max_n_pairs = total_n_atoms * list->maxneighs;
+        uint64_t max_n_pairs = (uint64_t) total_n_atoms * list->maxneighs;
         // Allocate for a much smaller number of pairs to avoid wasting memory
         // (especially when the interaction range is much larger than the NL
         // cutoff)
         auto pairs_capacity = std::max(
             std::max(
-                static_cast<size_t>(max_n_pairs * cutoff_ratio / 1000),
+                static_cast<uint64_t>(max_n_pairs * cutoff_ratio / 1000),
                 100ul
             ),
             nl.samples.extent(0)

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -270,24 +270,88 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts_old() {
 void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto _ = MetatomicTimer("identifying periodic ghosts");
     auto total_n_atoms = atom->nlocal + atom->nghost;
-    original_atom_id_.clear();                             
+    double** x = atom->x;
+
+    // Ghost shell bounds: subdomain expanded by the interaction range.
+    // The direct inter-domain ghost (not a periodic image) will always be
+    // inside this region.
+    auto cut = options_.interaction_range;
+    double ghost_lo[3] = {
+        domain->sublo[0] - cut,
+        domain->sublo[1] - cut,
+        domain->sublo[2] - cut,
+    };
+    double ghost_hi[3] = {
+        domain->subhi[0] + cut,
+        domain->subhi[1] + cut,
+        domain->subhi[2] + cut,
+    };
+
+    // First pass: for each unique tag among ghosts, find the representative.
+    // For inter-domain ghosts (tag not owned locally), pick the one inside
+    // the ghost shell (the direct copy, not a periodic image). This is
+    // deterministic regardless of ghost atom ordering.
+    local_atoms_tags_.clear();
+    for (int i = 0; i < atom->nlocal; i++) {
+        local_atoms_tags_.emplace(atom->tag[i], i);
+    }
+
+    ghost_atoms_tags_.clear();
+    for (int i = atom->nlocal; i < total_n_atoms; i++) {
+        auto tag = atom->tag[i];
+        if (local_atoms_tags_.count(tag)) {
+            continue;  // owned locally, local atom is the representative
+        }
+
+        auto it = ghost_atoms_tags_.find(tag);
+        if (it == ghost_atoms_tags_.end()) {
+            // first ghost with this tag
+            ghost_atoms_tags_.emplace(tag, i);
+        } else {
+            // pick the ghost that is inside the ghost shell
+            bool current_in_shell =
+                x[i][0] >= ghost_lo[0] && x[i][0] <= ghost_hi[0] &&
+                x[i][1] >= ghost_lo[1] && x[i][1] <= ghost_hi[1] &&
+                x[i][2] >= ghost_lo[2] && x[i][2] <= ghost_hi[2];
+            if (current_in_shell) {
+                it->second = i;  // replace with the in-shell ghost
+            }
+        }
+    }
+
+    // Second pass: build the mapping arrays
+    original_atom_id_.clear();
     original_atom_id_.reserve(total_n_atoms);
     lmp_to_mta_.clear();
     lmp_to_mta_.reserve(total_n_atoms);
     mta_to_lmp.clear();
     mta_to_lmp.reserve(total_n_atoms);
-    
-    for (int i = 0; i < total_n_atoms; i++) {
-        int mapped = atom->map(atom->tag[i]);
-        original_atom_id_.emplace_back(mapped);
 
-        if (mapped == i) {
-            // this atom is the representative for its tag
-            lmp_to_mta_.emplace_back(mta_to_lmp.size());
-            mta_to_lmp.emplace_back(i);
-        } else {
-            // periodic image, excluded from metatensor
+    for (int i = 0; i < atom->nlocal; i++) {
+        original_atom_id_.emplace_back(i);
+        lmp_to_mta_.emplace_back(mta_to_lmp.size());
+        mta_to_lmp.emplace_back(i);
+    }
+
+    for (int i = atom->nlocal; i < total_n_atoms; i++) {
+        auto tag = atom->tag[i];
+        auto local_it = local_atoms_tags_.find(tag);
+        if (local_it != local_atoms_tags_.end()) {
+            // periodic image of a local atom
+            original_atom_id_.emplace_back(local_it->second);
             lmp_to_mta_.emplace_back(-1);
+        } else {
+            auto ghost_it = ghost_atoms_tags_.find(tag);
+            auto representative = ghost_it->second;
+            original_atom_id_.emplace_back(representative);
+            if (representative == i) {
+                // this ghost IS the representative
+                lmp_to_mta_.emplace_back(mta_to_lmp.size());
+                mta_to_lmp.emplace_back(i);
+            } else {
+                // periodic image of an inter-domain ghost
+                lmp_to_mta_.emplace_back(-1);
+            }
         }
     }
 }
@@ -643,6 +707,36 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
 
     this->guess_periodic_ghosts_old();
     this->guess_periodic_ghosts();
+
+    {
+        static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+        if (debug_nl) {
+            int n_map_minus1 = 0;
+            int n_atoms_original = 0;
+            for (int i = 0; i < atom->nlocal + atom->nghost; i++) {
+                int mapped = atom->map(atom->tag[i]);
+                if (mapped == -1) {
+                    n_map_minus1++;
+                    if (n_map_minus1 <= 5) {
+                        fprintf(stderr, "[rank %d] atom->map returned -1 for i=%d tag=%lld (ghost=%s)\n",
+                            comm->me, i, (long long)atom->tag[i], i >= atom->nlocal ? "yes" : "no");
+                    }
+                }
+                if (original_atom_id_[i] == i) n_atoms_original++;
+            }
+            fprintf(stderr, "\nmetatomic-cpu-map-debug [rank %d]: n_map_minus1=%d n_atoms_original=%d mta_to_lmp_size=%zu\n",
+                comm->me, n_map_minus1, n_atoms_original, mta_to_lmp.size());
+        }
+
+        if (debug_nl) {
+            int64_t checksum = 0;
+            for (int i = 0; i < atom->nlocal + atom->nghost; i++) {
+                checksum += (int64_t)original_atom_id_[i] * (i + 1);
+            }
+            fprintf(stderr, "\nmetatomic-cpu-map-debug [rank %d]: checksum=%lld\n",
+                comm->me, (long long)checksum);
+        }
+    }
 
     // Only keep the atoms which are not periodic images of other atoms
     auto mta_to_lmp_tensor = torch::from_blob(

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -24,8 +24,6 @@
 
 #include "neigh_list.h"
 
-#include <cstdio>
-#include <cstdlib>
 #include <string>
 
 #include <metatensor/torch.hpp>
@@ -309,12 +307,8 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
     auto dtype = system->positions().scalar_type();
     auto device = system->positions().device();
 
-    static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
-
     double** x = atom->x;
     auto cell_inv = this->cell_inverse();
-
-    auto stats = std::array<int, 7>{0, 0, 0, 0, 0, 0, 0};
 
     for (auto& nl: nl_requests_) {
         {
@@ -334,38 +328,23 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
                 auto neighbors = list->firstneigh[atom_i];
                 for (int jj=0; jj<list->numneigh[atom_i]; jj++) {
-
-                    if (debug_nl) {
-                        // total num_pairs before any filtering
-                        stats[0] += 1;
-                    }
-
                     auto atom_j = neighbors[jj] & NEIGHMASK;
                     auto original_atom_j = original_atom_id_[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
-                        if (debug_nl) {
-                            stats[1] += 1;
-                        }
                         continue;
                     }
 
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
-                        if (debug_nl) {
-                            stats[2] += 1;
-                        }
                         continue;
                     }
 
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
-                        if (debug_nl) {
-                            stats[3] += 1;
-                        }
                         continue;
                     }
 
@@ -383,9 +362,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
-                        if (debug_nl) {
-                            stats[4] += 1;
-                        }
                         continue;
                     }
 
@@ -420,9 +396,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
-                                if (debug_nl) {
-                                    stats[5] += 1;
-                                }
                                 continue;
                             }
 
@@ -442,16 +415,9 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                                 //  X X X │ X X X
                                 //  X X X │ X X X
                                 //  X X X │ X X X
-                                if (debug_nl) {
-                                    stats[5] += 1;
-                                }
                                 continue;
                             }
                         }
-                    }
-
-                    if (debug_nl) {
-                        stats[6] += 1;
                     }
 
                     auto sample = std::array<int32_t, 5>{
@@ -476,19 +442,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     }
                 }
             }
-        }
-
-        if (debug_nl) {
-            std::fprintf(stderr,
-                "\nmetatomic-cpu-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
-                "  nlocal=%d nghost=%d inum=%d gnum=%d\n"
-                "  total_checked=%d f_half_list=%d f_both_ghosts=%d\n"
-                "  f_ghost_orig=%d f_cutoff=%d f_half_self_image=%d\n"
-                "  written=%d\n",
-                comm->me, nl.cutoff, nl.options->full_list() ? "true" : "false",
-                 atom->nlocal, atom->nghost, list->inum, list->gnum,
-                 stats[0], stats[1], stats[2], stats[3], stats[4], stats[5], stats[6]
-            );
         }
 
         int64_t n_pairs = nl.samples.size();

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -26,6 +26,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <string>
 
 #include <metatensor/torch.hpp>
 
@@ -207,61 +208,86 @@ static std::array<int32_t, 3> cell_shifts(
     return {shift_a, shift_b, shift_c};
 }
 
+// void MetatomicSystemAdaptor::guess_periodic_ghosts() {
+//     auto _ = MetatomicTimer("identifying periodic ghosts");
+//     auto total_n_atoms = atom->nlocal + atom->nghost;
+
+//     // Collect the local atom id of all local & ghosts atoms, mapping ghosts
+//     // atoms which are periodic images of local atoms back to the local atoms.
+//     //
+//     // metatomic expects pairs corresponding to periodic atoms to be between
+//     // the main atoms, but using the actual distance vector between the atom and
+//     // the ghost.
+//     original_atom_id_.clear();
+//     original_atom_id_.reserve(total_n_atoms);
+
+//     lmp_to_mta_.clear();
+//     lmp_to_mta_.reserve(total_n_atoms);
+
+//     mta_to_lmp.clear();
+//     mta_to_lmp.reserve(total_n_atoms);
+
+//     // identify all local atom by their LAMMPS atom tag.
+//     local_atoms_tags_.clear();
+//     for (int i=0; i<atom->nlocal; i++) {
+//         original_atom_id_.emplace_back(i);
+//         lmp_to_mta_.emplace_back(i);
+//         mta_to_lmp.emplace_back(i);
+//         local_atoms_tags_.emplace(atom->tag[i], i);
+//     }
+
+//     // now loop over ghosts & map them back to the main cell if needed
+//     ghost_atoms_tags_.clear();
+//     for (int i=atom->nlocal; i<total_n_atoms; i++) {
+//         auto tag = atom->tag[i];
+//         auto it = local_atoms_tags_.find(tag);
+//         if (it != local_atoms_tags_.end()) {
+//             // this is the periodic image of an atom already owned by this domain
+//             original_atom_id_.emplace_back(it->second);
+//             lmp_to_mta_.emplace_back(-1);
+//         } else {
+//             // this can either be a periodic image of an atom owned by another
+//             // domain, or directly an atom from another domain. Since we can not
+//             // really distinguish between these, we take the first atom as the
+//             // "main" one and remap all atoms with the same tag to the first one
+//             auto it = ghost_atoms_tags_.find(tag);
+//             if (it != ghost_atoms_tags_.end()) {
+//                 // we already found this atom elsewhere in the system
+//                 original_atom_id_.emplace_back(it->second);
+//                 lmp_to_mta_.emplace_back(-1);
+//             } else {
+//                 // this is the first time we are seeing this atom
+//                 original_atom_id_.emplace_back(i);
+//                 ghost_atoms_tags_.emplace(tag, i);
+
+//                 lmp_to_mta_.emplace_back(mta_to_lmp.size());
+//                 mta_to_lmp.emplace_back(i);
+//             }
+//         }
+//     }
+// }
+
 void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto _ = MetatomicTimer("identifying periodic ghosts");
     auto total_n_atoms = atom->nlocal + atom->nghost;
-
-    // Collect the local atom id of all local & ghosts atoms, mapping ghosts
-    // atoms which are periodic images of local atoms back to the local atoms.
-    //
-    // metatomic expects pairs corresponding to periodic atoms to be between
-    // the main atoms, but using the actual distance vector between the atom and
-    // the ghost.
-    original_atom_id_.clear();
+    original_atom_id_.clear();                             
     original_atom_id_.reserve(total_n_atoms);
-
     lmp_to_mta_.clear();
     lmp_to_mta_.reserve(total_n_atoms);
-
     mta_to_lmp.clear();
     mta_to_lmp.reserve(total_n_atoms);
+    
+    for (int i = 0; i < total_n_atoms; i++) {
+        int mapped = atom->map(atom->tag[i]);
+        original_atom_id_.emplace_back(mapped);
 
-    // identify all local atom by their LAMMPS atom tag.
-    local_atoms_tags_.clear();
-    for (int i=0; i<atom->nlocal; i++) {
-        original_atom_id_.emplace_back(i);
-        lmp_to_mta_.emplace_back(i);
-        mta_to_lmp.emplace_back(i);
-        local_atoms_tags_.emplace(atom->tag[i], i);
-    }
-
-    // now loop over ghosts & map them back to the main cell if needed
-    ghost_atoms_tags_.clear();
-    for (int i=atom->nlocal; i<total_n_atoms; i++) {
-        auto tag = atom->tag[i];
-        auto it = local_atoms_tags_.find(tag);
-        if (it != local_atoms_tags_.end()) {
-            // this is the periodic image of an atom already owned by this domain
-            original_atom_id_.emplace_back(it->second);
-            lmp_to_mta_.emplace_back(-1);
+        if (mapped == i) {
+            // this atom is the representative for its tag
+            lmp_to_mta_.emplace_back(mta_to_lmp.size());
+            mta_to_lmp.emplace_back(i);
         } else {
-            // this can either be a periodic image of an atom owned by another
-            // domain, or directly an atom from another domain. Since we can not
-            // really distinguish between these, we take the first atom as the
-            // "main" one and remap all atoms with the same tag to the first one
-            auto it = ghost_atoms_tags_.find(tag);
-            if (it != ghost_atoms_tags_.end()) {
-                // we already found this atom elsewhere in the system
-                original_atom_id_.emplace_back(it->second);
-                lmp_to_mta_.emplace_back(-1);
-            } else {
-                // this is the first time we are seeing this atom
-                original_atom_id_.emplace_back(i);
-                ghost_atoms_tags_.emplace(tag, i);
-
-                lmp_to_mta_.emplace_back(mta_to_lmp.size());
-                mta_to_lmp.emplace_back(i);
-            }
+            // periodic image, excluded from metatensor
+            lmp_to_mta_.emplace_back(-1);
         }
     }
 }
@@ -277,6 +303,8 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
     double** x = atom->x;
     auto cell_inv = this->cell_inverse();
 
+    auto stats = std::array<int, 7>{0, 0, 0, 0, 0, 0, 0};
+
     for (auto& nl: nl_requests_) {
         {
             auto _ = MetatomicTimer("filtering LAMMPS neighbor list");
@@ -284,53 +312,79 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
             auto cutoff2 = nl.cutoff * nl.cutoff;
             auto full_list = nl.options->full_list();
 
-            int64_t total_checked = 0;
-            int64_t f_half_list = 0;
-            int64_t f_both_ghosts = 0;
-            int64_t f_ghost_orig = 0;
-            int64_t f_cutoff = 0;
-            int64_t f_half_self_image = 0;
-            int64_t written = 0;
-            int64_t sum_i = 0, sum_j = 0;
-            int64_t n_i_original = 0, n_j_original = 0;
-            int64_t total_local = 0;
-
             // convert from LAMMPS neighbors list to metatomic format
             nl.samples.clear();
             nl.distances_f32.clear();
             nl.distances_f64.clear();
             for (int ii=0; ii<(list->inum + list->gnum); ii++) {
                 auto atom_i = list->ilist[ii];
+                // auto original_atom_i = atom->map(atom->tag[atom_i]);
                 auto original_atom_i = original_atom_id_[atom_i];
+                // auto mtt_i_differs = (original_atom_i_mtt != original_atom_i);
                 auto i_is_original = (atom_i == original_atom_i);
 
-                auto neighbors = list->firstneigh[ii];
-                for (int jj=0; jj<list->numneigh[ii]; jj++) {
-                    total_checked++;
-                    auto atom_j = neighbors[jj] & NEIGHMASK;
-                    auto original_atom_j = original_atom_id_[atom_j];
-                    auto j_is_original = (atom_j == original_atom_j);
-                    sum_i += atom_i;
-                    sum_j += atom_j;
-                    if (i_is_original) n_i_original++;
-                    if (j_is_original) n_j_original++;
+                auto neighbors = list->firstneigh[atom_i];
+                for (int jj=0; jj<list->numneigh[atom_i]; jj++) {
 
+                    if (debug_nl) {
+                        // total num_pairs before any filtering
+                        stats[0] += 1;
+                    }
+
+                    auto atom_j = neighbors[jj] & NEIGHMASK;
+                    // auto original_atom_j = atom->map(atom->tag[atom_j]);
+                    auto original_atom_j = original_atom_id_[atom_j];
+                    // auto mtt_j_differs = (original_atom_j_mtt != original_atom_j);
+                    auto j_is_original = (atom_j == original_atom_j);
+
+                    // std::string msg = "[rank: " + std::to_string(comm->me) + "]";
+                    // msg += " pair: " + std::to_string(atom_i) + " (original: " + std::to_string(original_atom_i) + " mtt: " + std::to_string(original_atom_i_mtt) + ") - " + std::to_string(atom_j) + " (original: " + std::to_string(original_atom_j) + " mtt: " + std::to_string(original_atom_j_mtt) + ")";
+
+                    // std::string status = "";
+                    // auto id_status = "";
+                    // if (mtt_i_differs || mtt_j_differs) {
+                    //     id_status = "[MTT DIFFERS]";
+                    // }
+
+                    // msg += id_status;
+                    
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
-                        f_half_list++;
+                        // status = " (skipped by half-list condition)";
+                        // msg += status;
+                        // if (comm->me == 0 && debug_nl) {
+                        //     std::cout << msg << std::endl;
+                        // }
+                        if (debug_nl) {
+                            stats[1] += 1;
+                        }
                         continue;
                     }
 
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
-                        f_both_ghosts++;
+                        // status = " (skipped because both atoms are ghosts)";
+                        // msg += status;
+                        // if (comm->me == 0 && debug_nl) {
+                        //     std::cout << msg << std::endl;
+                        // }
+                        if (debug_nl) {
+                            stats[2] += 1;
+                        }
                         continue;
                     }
 
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
-                        f_ghost_orig++;
+                        // status = " (skipped because atom_i is a ghost and atom_j is the original)";
+                        // msg += status;
+                        // if (comm->me == 0 && debug_nl) {
+                        //     std::cout << msg << std::endl;
+                        // }
+                        if (debug_nl) {
+                            stats[3] += 1;
+                        }
                         continue;
                     }
 
@@ -348,9 +402,17 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
-                        f_cutoff++;
+                        // status = " (skipped by cutoff filter)";
+                        // msg += status;
+                        // if (comm->me == 0 && debug_nl) {
+                        //     std::cout << msg << std::endl;
+                        // }
+                        if (debug_nl) {
+                            stats[4] += 1;
+                        }
                         continue;
                     }
+
 
                     // Compute the cell shift for the pair.
                     auto shift_i = std::array<double, 3>{
@@ -383,7 +445,14 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
-                                f_half_self_image++;
+                                // status = " (skipped by negative half-space condition)";
+                                // msg += status;
+                                // if (comm->me == 0 && debug_nl) {
+                                //     std::cout << msg << std::endl;
+                                // }
+                                if (debug_nl) {
+                                    stats[5] += 1;
+                                }
                                 continue;
                             }
 
@@ -403,10 +472,28 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                                 //  X X X │ X X X
                                 //  X X X │ X X X
                                 //  X X X │ X X X
-                                f_half_self_image++;
+
+                                // status = " (skipped by negative half-plane condition)";
+                                // msg += status;
+                                // if (comm->me == 0 && debug_nl) {
+                                //     std::cout << msg << std::endl;
+                                // }
+                                if (debug_nl) {
+                                    stats[5] += 1;
+                                }
                                 continue;
                             }
                         }
+                    }
+
+                    // status = " (kept)";
+                    // msg += status;
+                    // if (comm->me == 0 && debug_nl) {
+                    //     std::cout << msg << std::endl;
+                    // }
+
+                    if (debug_nl) {
+                        stats[6] += 1;
                     }
 
                     auto sample = std::array<int32_t, 5>{
@@ -416,8 +503,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                         shift[1],
                         shift[2],
                     };
-
-                    written++;
                     nl.samples.push_back(sample);
                     if (dtype == torch::kFloat64) {
                         nl.distances_f64.push_back(distance);
@@ -433,23 +518,19 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     }
                 }
             }
+        }
 
-            if (debug_nl) {
-                fprintf(stderr,
-                    "metatomic-cpu-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
-                    "  nlocal=%d nghost=%d inum=%d gnum=%d\n"
-                    "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
-                    "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
-                    "  written=%lld\n"
-                    "  sum_i=%lld sum_j=%lld n_i_original=%lld n_j_original=%lld\n",
-                    comm->me, nl.cutoff, full_list ? "true" : "false",
-                    atom->nlocal, atom->nghost, list->inum, list->gnum,
-                    (long long)total_checked, (long long)f_half_list, (long long)f_both_ghosts,
-                    (long long)f_ghost_orig, (long long)f_cutoff, (long long)f_half_self_image,
-                    (long long)written,
-                    (long long)sum_i, (long long)sum_j, (long long)n_i_original, (long long)n_j_original
-                );
-            }
+        if (debug_nl) {
+            std::fprintf(stderr,
+                "\nmetatomic-cpu-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
+                "  nlocal=%d nghost=%d inum=%d gnum=%d\n"
+                "  total_checked=%d f_half_list=%d f_both_ghosts=%d\n"
+                "  f_ghost_orig=%d f_cutoff=%d f_half_self_image=%d\n"
+                "  written=%d\n",
+                comm->me, nl.cutoff, nl.options->full_list() ? "true" : "false",
+                 atom->nlocal, atom->nghost, list->inum, list->gnum,
+                 stats[0], stats[1], stats[2], stats[3], stats[4], stats[5], stats[6]
+            );
         }
 
         int64_t n_pairs = nl.samples.size();

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -291,6 +291,8 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
             int64_t f_cutoff = 0;
             int64_t f_half_self_image = 0;
             int64_t written = 0;
+            int64_t sum_i = 0, sum_j = 0;
+            int64_t n_i_original = 0, n_j_original = 0;
 
             // convert from LAMMPS neighbors list to metatomic format
             nl.samples.clear();
@@ -307,6 +309,10 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     auto atom_j = neighbors[jj] & NEIGHMASK;
                     auto original_atom_j = original_atom_id_[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
+                    sum_i += atom_i;
+                    sum_j += atom_j;
+                    if (i_is_original) n_i_original++;
+                    if (j_is_original) n_j_original++;
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
@@ -433,12 +439,14 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     "  nlocal=%d nghost=%d inum=%d gnum=%d\n"
                     "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
                     "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
-                    "  written=%lld\n",
+                    "  written=%lld\n"
+                    "  sum_i=%lld sum_j=%lld n_i_original=%lld n_j_original=%lld\n",
                     comm->me, nl.cutoff, full_list ? "true" : "false",
                     atom->nlocal, atom->nghost, list->inum, list->gnum,
                     (long long)total_checked, (long long)f_half_list, (long long)f_both_ghosts,
                     (long long)f_ghost_orig, (long long)f_cutoff, (long long)f_half_self_image,
-                    (long long)written
+                    (long long)written,
+                    (long long)sum_i, (long long)sum_j, (long long)n_i_original, (long long)n_j_original
                 );
             }
         }

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -211,13 +211,21 @@ static std::array<int32_t, 3> cell_shifts(
 void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto _ = MetatomicTimer("identifying periodic ghosts");
     auto total_n_atoms = atom->nlocal + atom->nghost;
+    double** x = atom->x;
 
-    // First pass: for each unique tag among ghosts, find the representative.
-    // For inter-domain ghosts (tag not owned locally), pick the one inside
-    // the global simulation box [boxlo, boxhi). LAMMPS keeps all owned atoms
-    // inside this box; when communicated as a ghost, the direct copy retains
-    // this in-box position while periodic images are shifted by cell vectors
-    // and land outside. This is deterministic regardless of ghost ordering.
+    // Subdomain center: used as the reference point for deterministic
+    // representative selection. Among all ghosts sharing a tag, the one
+    // closest to the subdomain center is chosen. This is deterministic
+    // regardless of ghost array ordering (which is non-deterministic on
+    // GPU) because ghost positions depend only on the original atom
+    // position and exact cell-vector shifts — both of which are
+    // order-independent. Picking the closest ghost also gives the most
+    // natural representative for cell-shift calculations.
+    double center[3] = {
+        0.5 * (domain->sublo[0] + domain->subhi[0]),
+        0.5 * (domain->sublo[1] + domain->subhi[1]),
+        0.5 * (domain->sublo[2] + domain->subhi[2])
+    };
     local_atoms_tags_.clear();
     for (int i = 0; i < atom->nlocal; i++) {
         local_atoms_tags_.emplace(atom->tag[i], i);
@@ -232,12 +240,29 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts() {
 
         auto it = ghost_atoms_tags_.find(tag);
         if (it == ghost_atoms_tags_.end()) {
-            // first ghost with this tag — tentative representative
             ghost_atoms_tags_.emplace(tag, i);
-        } else if (domain->inside(atom->x[i])) {
-            // this ghost is inside the global box, so it is the direct
-            // inter-domain copy — overwrite the tentative representative
-            it->second = i;
+        } else {
+            // Replace if the new ghost is closer to the subdomain center.
+            double dist_new = 0, dist_old = 0;
+            for (int d = 0; d < 3; d++) {
+                double dn = x[i][d] - center[d];
+                double de = x[it->second][d] - center[d];
+                dist_new += dn * dn;
+                dist_old += de * de;
+            }
+            if (dist_new < dist_old) {
+                it->second = i;
+            } else if (dist_new == dist_old) {
+                // Lexicographic tiebreaker for the rare equal-distance case
+                for (int d = 0; d < 3; d++) {           
+                    if (x[i][d] < x[it->second][d]) {
+                        it->second = i;
+                        break;
+                    } else if (x[i][d] > x[it->second][d]) {
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -211,6 +211,11 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto total_n_atoms = atom->nlocal + atom->nghost;
     double** x = atom->x;
 
+    local_atoms_tags_.clear();
+    for (int i = 0; i < atom->nlocal; i++) {
+        local_atoms_tags_.emplace(atom->tag[i], i);
+    }
+
     // Subdomain center: used as the reference point for deterministic
     // representative selection. Among all ghosts sharing a tag, the one
     // closest to the subdomain center is chosen. This is deterministic
@@ -219,15 +224,17 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     // position and exact cell-vector shifts — both of which are
     // order-independent. Picking the closest ghost also gives the most
     // natural representative for cell-shift calculations.
+
     double center[3] = {
         0.5 * (domain->sublo[0] + domain->subhi[0]),
         0.5 * (domain->sublo[1] + domain->subhi[1]),
         0.5 * (domain->sublo[2] + domain->subhi[2])
     };
-    local_atoms_tags_.clear();
-    for (int i = 0; i < atom->nlocal; i++) {
-        local_atoms_tags_.emplace(atom->tag[i], i);
-    }
+
+    // We do the first pass over ghost atoms to find the representative for
+    // for each tag, then a second pass to build the mapping arrays. This ensures
+    // that the representative selection is not affected by the order of ghost
+    // atoms in the arrays, which can be non-deterministic on GPU.
 
     ghost_atoms_tags_.clear();
     for (int i = atom->nlocal; i < total_n_atoms; i++) {

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -211,9 +211,19 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto total_n_atoms = atom->nlocal + atom->nghost;
     double** x = atom->x;
 
+    original_atom_id_.clear();
+    original_atom_id_.reserve(total_n_atoms);
+    lmp_to_mta_.clear();
+    lmp_to_mta_.reserve(total_n_atoms);
+    mta_to_lmp.clear();
+    mta_to_lmp.reserve(total_n_atoms);
+
     local_atoms_tags_.clear();
     for (int i = 0; i < atom->nlocal; i++) {
         local_atoms_tags_.emplace(atom->tag[i], i);
+        original_atom_id_.emplace_back(i);
+        lmp_to_mta_.emplace_back(mta_to_lmp.size());
+        mta_to_lmp.emplace_back(i);
     }
 
     // Subdomain center: used as the reference point for deterministic
@@ -271,20 +281,8 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts() {
         }
     }
 
-    // Second pass: build the mapping arrays
-    original_atom_id_.clear();
-    original_atom_id_.reserve(total_n_atoms);
-    lmp_to_mta_.clear();
-    lmp_to_mta_.reserve(total_n_atoms);
-    mta_to_lmp.clear();
-    mta_to_lmp.reserve(total_n_atoms);
-
-    for (int i = 0; i < atom->nlocal; i++) {
-        original_atom_id_.emplace_back(i);
-        lmp_to_mta_.emplace_back(mta_to_lmp.size());
-        mta_to_lmp.emplace_back(i);
-    }
-
+    // Second pass over the ghost atoms to build the mapping arrays,
+    // since now we know which one is the representative for each tag.
     for (int i = atom->nlocal; i < total_n_atoms; i++) {
         auto tag = atom->tag[i];
         auto local_it = local_atoms_tags_.find(tag);

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -18,10 +18,14 @@
 #include "metatomic_timer.h"
 
 #include "atom.h"
+#include "comm.h"
 #include "domain.h"
 #include "error.h"
 
 #include "neigh_list.h"
+
+#include <cstdio>
+#include <cstdlib>
 
 #include <metatensor/torch.hpp>
 
@@ -268,6 +272,8 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
     auto dtype = system->positions().scalar_type();
     auto device = system->positions().device();
 
+    static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+
     double** x = atom->x;
     auto cell_inv = this->cell_inverse();
 
@@ -277,6 +283,14 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
             auto cutoff2 = nl.cutoff * nl.cutoff;
             auto full_list = nl.options->full_list();
+
+            int64_t total_checked = 0;
+            int64_t f_half_list = 0;
+            int64_t f_both_ghosts = 0;
+            int64_t f_ghost_orig = 0;
+            int64_t f_cutoff = 0;
+            int64_t f_half_self_image = 0;
+            int64_t written = 0;
 
             // convert from LAMMPS neighbors list to metatomic format
             nl.samples.clear();
@@ -289,23 +303,27 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
                 auto neighbors = list->firstneigh[ii];
                 for (int jj=0; jj<list->numneigh[ii]; jj++) {
+                    total_checked++;
                     auto atom_j = neighbors[jj] & NEIGHMASK;
                     auto original_atom_j = original_atom_id_[atom_j];
                     auto j_is_original = (atom_j == original_atom_j);
 
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
+                        f_half_list++;
                         continue;
                     }
 
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
+                        f_both_ghosts++;
                         continue;
                     }
 
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
+                        f_ghost_orig++;
                         continue;
                     }
 
@@ -323,6 +341,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
+                        f_cutoff++;
                         continue;
                     }
 
@@ -357,6 +376,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
+                                f_half_self_image++;
                                 continue;
                             }
 
@@ -376,6 +396,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                                 //  X X X │ X X X
                                 //  X X X │ X X X
                                 //  X X X │ X X X
+                                f_half_self_image++;
                                 continue;
                             }
                         }
@@ -389,6 +410,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                         shift[2],
                     };
 
+                    written++;
                     nl.samples.push_back(sample);
                     if (dtype == torch::kFloat64) {
                         nl.distances_f64.push_back(distance);
@@ -403,6 +425,21 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                         error->one(FLERR, "invalid dtype, this is a bug");
                     }
                 }
+            }
+
+            if (debug_nl) {
+                fprintf(stderr,
+                    "metatomic-cpu-nl-debug [rank %d] (cutoff=%.4f, full_list=%s):\n"
+                    "  nlocal=%d nghost=%d inum=%d gnum=%d\n"
+                    "  total_checked=%lld f_half_list=%lld f_both_ghosts=%lld\n"
+                    "  f_ghost_orig=%lld f_cutoff=%lld f_half_self_image=%lld\n"
+                    "  written=%lld\n",
+                    comm->me, nl.cutoff, full_list ? "true" : "false",
+                    atom->nlocal, atom->nghost, list->inum, list->gnum,
+                    (long long)total_checked, (long long)f_half_list, (long long)f_both_ghosts,
+                    (long long)f_ghost_orig, (long long)f_cutoff, (long long)f_half_self_image,
+                    (long long)written
+                );
             }
         }
 

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -208,64 +208,64 @@ static std::array<int32_t, 3> cell_shifts(
     return {shift_a, shift_b, shift_c};
 }
 
-// void MetatomicSystemAdaptor::guess_periodic_ghosts() {
-//     auto _ = MetatomicTimer("identifying periodic ghosts");
-//     auto total_n_atoms = atom->nlocal + atom->nghost;
+void MetatomicSystemAdaptor::guess_periodic_ghosts_old() {
+    auto _ = MetatomicTimer("identifying periodic ghosts (old method)");
+    auto total_n_atoms = atom->nlocal + atom->nghost;
 
-//     // Collect the local atom id of all local & ghosts atoms, mapping ghosts
-//     // atoms which are periodic images of local atoms back to the local atoms.
-//     //
-//     // metatomic expects pairs corresponding to periodic atoms to be between
-//     // the main atoms, but using the actual distance vector between the atom and
-//     // the ghost.
-//     original_atom_id_.clear();
-//     original_atom_id_.reserve(total_n_atoms);
+    // Collect the local atom id of all local & ghosts atoms, mapping ghosts
+    // atoms which are periodic images of local atoms back to the local atoms.
+    //
+    // metatomic expects pairs corresponding to periodic atoms to be between
+    // the main atoms, but using the actual distance vector between the atom and
+    // the ghost.
+    original_atom_id_old_.clear();
+    original_atom_id_old_.reserve(total_n_atoms);
 
-//     lmp_to_mta_.clear();
-//     lmp_to_mta_.reserve(total_n_atoms);
+    lmp_to_mta_old_.clear();
+    lmp_to_mta_old_.reserve(total_n_atoms);
 
-//     mta_to_lmp.clear();
-//     mta_to_lmp.reserve(total_n_atoms);
+    mta_to_lmp.clear();
+    mta_to_lmp.reserve(total_n_atoms);
 
-//     // identify all local atom by their LAMMPS atom tag.
-//     local_atoms_tags_.clear();
-//     for (int i=0; i<atom->nlocal; i++) {
-//         original_atom_id_.emplace_back(i);
-//         lmp_to_mta_.emplace_back(i);
-//         mta_to_lmp.emplace_back(i);
-//         local_atoms_tags_.emplace(atom->tag[i], i);
-//     }
+    // identify all local atom by their LAMMPS atom tag.
+    local_atoms_tags_.clear();
+    for (int i=0; i<atom->nlocal; i++) {
+        original_atom_id_old_.emplace_back(i);
+        lmp_to_mta_old_.emplace_back(i);
+        mta_to_lmp.emplace_back(i);
+        local_atoms_tags_.emplace(atom->tag[i], i);
+    }
 
-//     // now loop over ghosts & map them back to the main cell if needed
-//     ghost_atoms_tags_.clear();
-//     for (int i=atom->nlocal; i<total_n_atoms; i++) {
-//         auto tag = atom->tag[i];
-//         auto it = local_atoms_tags_.find(tag);
-//         if (it != local_atoms_tags_.end()) {
-//             // this is the periodic image of an atom already owned by this domain
-//             original_atom_id_.emplace_back(it->second);
-//             lmp_to_mta_.emplace_back(-1);
-//         } else {
-//             // this can either be a periodic image of an atom owned by another
-//             // domain, or directly an atom from another domain. Since we can not
-//             // really distinguish between these, we take the first atom as the
-//             // "main" one and remap all atoms with the same tag to the first one
-//             auto it = ghost_atoms_tags_.find(tag);
-//             if (it != ghost_atoms_tags_.end()) {
-//                 // we already found this atom elsewhere in the system
-//                 original_atom_id_.emplace_back(it->second);
-//                 lmp_to_mta_.emplace_back(-1);
-//             } else {
-//                 // this is the first time we are seeing this atom
-//                 original_atom_id_.emplace_back(i);
-//                 ghost_atoms_tags_.emplace(tag, i);
+    // now loop over ghosts & map them back to the main cell if needed
+    ghost_atoms_tags_.clear();
+    for (int i=atom->nlocal; i<total_n_atoms; i++) {
+        auto tag = atom->tag[i];
+        auto it = local_atoms_tags_.find(tag);
+        if (it != local_atoms_tags_.end()) {
+            // this is the periodic image of an atom already owned by this domain
+            original_atom_id_old_.emplace_back(it->second);
+            lmp_to_mta_old_.emplace_back(-1);
+        } else {
+            // this can either be a periodic image of an atom owned by another
+            // domain, or directly an atom from another domain. Since we can not
+            // really distinguish between these, we take the first atom as the
+            // "main" one and remap all atoms with the same tag to the first one
+            auto it = ghost_atoms_tags_.find(tag);
+            if (it != ghost_atoms_tags_.end()) {
+                // we already found this atom elsewhere in the system
+                original_atom_id_old_.emplace_back(it->second);
+                lmp_to_mta_old_.emplace_back(-1);
+            } else {
+                // this is the first time we are seeing this atom
+                original_atom_id_old_.emplace_back(i);
+                ghost_atoms_tags_.emplace(tag, i);
 
-//                 lmp_to_mta_.emplace_back(mta_to_lmp.size());
-//                 mta_to_lmp.emplace_back(i);
-//             }
-//         }
-//     }
-// }
+                lmp_to_mta_old_.emplace_back(mta_to_lmp.size());
+                mta_to_lmp.emplace_back(i);
+            }
+        }
+    }
+}
 
 void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto _ = MetatomicTimer("identifying periodic ghosts");
@@ -300,6 +300,8 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
     static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
 
+    static bool print_nl = (std::getenv("LAMMPS_METATOMIC_PRINT_NL") != nullptr);
+
     double** x = atom->x;
     auto cell_inv = this->cell_inverse();
 
@@ -318,9 +320,9 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
             nl.distances_f64.clear();
             for (int ii=0; ii<(list->inum + list->gnum); ii++) {
                 auto atom_i = list->ilist[ii];
-                // auto original_atom_i = atom->map(atom->tag[atom_i]);
                 auto original_atom_i = original_atom_id_[atom_i];
-                // auto mtt_i_differs = (original_atom_i_mtt != original_atom_i);
+                auto original_atom_i_mtt = original_atom_id_old_[atom_i];
+                auto mtt_i_differs = (original_atom_i_mtt != original_atom_i);
                 auto i_is_original = (atom_i == original_atom_i);
 
                 auto neighbors = list->firstneigh[atom_i];
@@ -332,29 +334,29 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     }
 
                     auto atom_j = neighbors[jj] & NEIGHMASK;
-                    // auto original_atom_j = atom->map(atom->tag[atom_j]);
                     auto original_atom_j = original_atom_id_[atom_j];
-                    // auto mtt_j_differs = (original_atom_j_mtt != original_atom_j);
+                    auto original_atom_j_mtt = original_atom_id_old_[atom_j];
+                    auto mtt_j_differs = (original_atom_j_mtt != original_atom_j);
                     auto j_is_original = (atom_j == original_atom_j);
 
-                    // std::string msg = "[rank: " + std::to_string(comm->me) + "]";
-                    // msg += " pair: " + std::to_string(atom_i) + " (original: " + std::to_string(original_atom_i) + " mtt: " + std::to_string(original_atom_i_mtt) + ") - " + std::to_string(atom_j) + " (original: " + std::to_string(original_atom_j) + " mtt: " + std::to_string(original_atom_j_mtt) + ")";
+                    std::string msg = "[rank: " + std::to_string(comm->me) + "]";
+                    msg += " pair: " + std::to_string(atom_i) + " (original: " + std::to_string(original_atom_i) + " mtt: " + std::to_string(original_atom_i_mtt) + ") - " + std::to_string(atom_j) + " (original: " + std::to_string(original_atom_j) + " mtt: " + std::to_string(original_atom_j_mtt) + ")";
 
-                    // std::string status = "";
-                    // auto id_status = "";
-                    // if (mtt_i_differs || mtt_j_differs) {
-                    //     id_status = "[MTT DIFFERS]";
-                    // }
+                    std::string status = "";
+                    auto id_status = "";
+                    if (mtt_i_differs || mtt_j_differs) {
+                        id_status = "[MTT DIFFERS]";
+                    }
 
-                    // msg += id_status;
+                    msg += id_status;
                     
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
-                        // status = " (skipped by half-list condition)";
-                        // msg += status;
-                        // if (comm->me == 0 && debug_nl) {
-                        //     std::cout << msg << std::endl;
-                        // }
+                        status = " (skipped by half-list condition)";
+                        msg += status;
+                        if (comm->me == 0 && print_nl) {
+                            std::cout << msg << std::endl;
+                        }
                         if (debug_nl) {
                             stats[1] += 1;
                         }
@@ -364,10 +366,10 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
                         // status = " (skipped because both atoms are ghosts)";
-                        // msg += status;
-                        // if (comm->me == 0 && debug_nl) {
-                        //     std::cout << msg << std::endl;
-                        // }
+                        msg += status;  
+                        if (comm->me == 0 && print_nl) {
+                            std::cout << msg << std::endl;
+                        }
                         if (debug_nl) {
                             stats[2] += 1;
                         }
@@ -377,11 +379,11 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
-                        // status = " (skipped because atom_i is a ghost and atom_j is the original)";
-                        // msg += status;
-                        // if (comm->me == 0 && debug_nl) {
-                        //     std::cout << msg << std::endl;
-                        // }
+                        status = " (skipped because atom_i is a ghost and atom_j is the original)";
+                        msg += status;
+                        if (comm->me == 0 && print_nl) {
+                            std::cout << msg << std::endl;
+                        }
                         if (debug_nl) {
                             stats[3] += 1;
                         }
@@ -402,11 +404,11 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
-                        // status = " (skipped by cutoff filter)";
-                        // msg += status;
-                        // if (comm->me == 0 && debug_nl) {
-                        //     std::cout << msg << std::endl;
-                        // }
+                        status = " (skipped by cutoff filter)";
+                        msg += status;
+                        if (comm->me == 0 && print_nl) {
+                            std::cout << msg << std::endl;
+                        }
                         if (debug_nl) {
                             stats[4] += 1;
                         }
@@ -445,11 +447,11 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
-                                // status = " (skipped by negative half-space condition)";
-                                // msg += status;
-                                // if (comm->me == 0 && debug_nl) {
-                                //     std::cout << msg << std::endl;
-                                // }
+                                status = " (skipped by negative half-space condition)";
+                                msg += status;
+                                if (comm->me == 0 && print_nl) {
+                                    std::cout << msg << std::endl;
+                                }
                                 if (debug_nl) {
                                     stats[5] += 1;
                                 }
@@ -473,11 +475,11 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                                 //  X X X │ X X X
                                 //  X X X │ X X X
 
-                                // status = " (skipped by negative half-plane condition)";
-                                // msg += status;
-                                // if (comm->me == 0 && debug_nl) {
-                                //     std::cout << msg << std::endl;
-                                // }
+                                status = " (skipped by negative half-plane condition)";
+                                msg += status;
+                                if (comm->me == 0 && print_nl) {
+                                    std::cout << msg << std::endl;
+                                }
                                 if (debug_nl) {
                                     stats[5] += 1;
                                 }
@@ -486,11 +488,11 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                         }
                     }
 
-                    // status = " (kept)";
-                    // msg += status;
-                    // if (comm->me == 0 && debug_nl) {
-                    //     std::cout << msg << std::endl;
-                    // }
+                    status = " (kept)";
+                    msg += status;
+                    if (comm->me == 0 && print_nl) {
+                        std::cout << msg << std::endl;
+                    }
 
                     if (debug_nl) {
                         stats[6] += 1;
@@ -639,19 +641,8 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
 
     cell.index_put_({torch::logical_not(pbc)}, torch::tensor({0.0}, tensor_options));
 
+    this->guess_periodic_ghosts_old();
     this->guess_periodic_ghosts();
-
-    {
-        static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
-        if (debug_nl) {
-            int n_atoms_original = 0;
-            for (size_t i = 0; i < original_atom_id_.size(); i++) {
-                if (original_atom_id_[i] == static_cast<int>(i)) n_atoms_original++;
-            }
-            fprintf(stderr, "metatomic-cpu-ghost-debug [rank %d]: total_atoms=%zu n_atoms_original=%d mta_to_lmp_size=%zu\n",
-                comm->me, original_atom_id_.size(), n_atoms_original, mta_to_lmp.size());
-        }
-    }
 
     // Only keep the atoms which are not periodic images of other atoms
     auto mta_to_lmp_tensor = torch::from_blob(

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -208,89 +208,16 @@ static std::array<int32_t, 3> cell_shifts(
     return {shift_a, shift_b, shift_c};
 }
 
-void MetatomicSystemAdaptor::guess_periodic_ghosts_old() {
-    auto _ = MetatomicTimer("identifying periodic ghosts (old method)");
-    auto total_n_atoms = atom->nlocal + atom->nghost;
-
-    // Collect the local atom id of all local & ghosts atoms, mapping ghosts
-    // atoms which are periodic images of local atoms back to the local atoms.
-    //
-    // metatomic expects pairs corresponding to periodic atoms to be between
-    // the main atoms, but using the actual distance vector between the atom and
-    // the ghost.
-    original_atom_id_old_.clear();
-    original_atom_id_old_.reserve(total_n_atoms);
-
-    lmp_to_mta_old_.clear();
-    lmp_to_mta_old_.reserve(total_n_atoms);
-
-    mta_to_lmp.clear();
-    mta_to_lmp.reserve(total_n_atoms);
-
-    // identify all local atom by their LAMMPS atom tag.
-    local_atoms_tags_.clear();
-    for (int i=0; i<atom->nlocal; i++) {
-        original_atom_id_old_.emplace_back(i);
-        lmp_to_mta_old_.emplace_back(i);
-        mta_to_lmp.emplace_back(i);
-        local_atoms_tags_.emplace(atom->tag[i], i);
-    }
-
-    // now loop over ghosts & map them back to the main cell if needed
-    ghost_atoms_tags_.clear();
-    for (int i=atom->nlocal; i<total_n_atoms; i++) {
-        auto tag = atom->tag[i];
-        auto it = local_atoms_tags_.find(tag);
-        if (it != local_atoms_tags_.end()) {
-            // this is the periodic image of an atom already owned by this domain
-            original_atom_id_old_.emplace_back(it->second);
-            lmp_to_mta_old_.emplace_back(-1);
-        } else {
-            // this can either be a periodic image of an atom owned by another
-            // domain, or directly an atom from another domain. Since we can not
-            // really distinguish between these, we take the first atom as the
-            // "main" one and remap all atoms with the same tag to the first one
-            auto it = ghost_atoms_tags_.find(tag);
-            if (it != ghost_atoms_tags_.end()) {
-                // we already found this atom elsewhere in the system
-                original_atom_id_old_.emplace_back(it->second);
-                lmp_to_mta_old_.emplace_back(-1);
-            } else {
-                // this is the first time we are seeing this atom
-                original_atom_id_old_.emplace_back(i);
-                ghost_atoms_tags_.emplace(tag, i);
-
-                lmp_to_mta_old_.emplace_back(mta_to_lmp.size());
-                mta_to_lmp.emplace_back(i);
-            }
-        }
-    }
-}
-
 void MetatomicSystemAdaptor::guess_periodic_ghosts() {
     auto _ = MetatomicTimer("identifying periodic ghosts");
     auto total_n_atoms = atom->nlocal + atom->nghost;
-    double** x = atom->x;
-
-    // Ghost shell bounds: subdomain expanded by the interaction range.
-    // The direct inter-domain ghost (not a periodic image) will always be
-    // inside this region.
-    auto cut = options_.interaction_range;
-    double ghost_lo[3] = {
-        domain->sublo[0] - cut,
-        domain->sublo[1] - cut,
-        domain->sublo[2] - cut,
-    };
-    double ghost_hi[3] = {
-        domain->subhi[0] + cut,
-        domain->subhi[1] + cut,
-        domain->subhi[2] + cut,
-    };
 
     // First pass: for each unique tag among ghosts, find the representative.
     // For inter-domain ghosts (tag not owned locally), pick the one inside
-    // the ghost shell (the direct copy, not a periodic image). This is
-    // deterministic regardless of ghost atom ordering.
+    // the global simulation box [boxlo, boxhi). LAMMPS keeps all owned atoms
+    // inside this box; when communicated as a ghost, the direct copy retains
+    // this in-box position while periodic images are shifted by cell vectors
+    // and land outside. This is deterministic regardless of ghost ordering.
     local_atoms_tags_.clear();
     for (int i = 0; i < atom->nlocal; i++) {
         local_atoms_tags_.emplace(atom->tag[i], i);
@@ -305,17 +232,12 @@ void MetatomicSystemAdaptor::guess_periodic_ghosts() {
 
         auto it = ghost_atoms_tags_.find(tag);
         if (it == ghost_atoms_tags_.end()) {
-            // first ghost with this tag
+            // first ghost with this tag — tentative representative
             ghost_atoms_tags_.emplace(tag, i);
-        } else {
-            // pick the ghost that is inside the ghost shell
-            bool current_in_shell =
-                x[i][0] >= ghost_lo[0] && x[i][0] <= ghost_hi[0] &&
-                x[i][1] >= ghost_lo[1] && x[i][1] <= ghost_hi[1] &&
-                x[i][2] >= ghost_lo[2] && x[i][2] <= ghost_hi[2];
-            if (current_in_shell) {
-                it->second = i;  // replace with the in-shell ghost
-            }
+        } else if (domain->inside(atom->x[i])) {
+            // this ghost is inside the global box, so it is the direct
+            // inter-domain copy — overwrite the tentative representative
+            it->second = i;
         }
     }
 
@@ -364,8 +286,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
     static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
 
-    static bool print_nl = (std::getenv("LAMMPS_METATOMIC_PRINT_NL") != nullptr);
-
     double** x = atom->x;
     auto cell_inv = this->cell_inverse();
 
@@ -385,8 +305,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
             for (int ii=0; ii<(list->inum + list->gnum); ii++) {
                 auto atom_i = list->ilist[ii];
                 auto original_atom_i = original_atom_id_[atom_i];
-                auto original_atom_i_mtt = original_atom_id_old_[atom_i];
-                auto mtt_i_differs = (original_atom_i_mtt != original_atom_i);
                 auto i_is_original = (atom_i == original_atom_i);
 
                 auto neighbors = list->firstneigh[atom_i];
@@ -399,28 +317,10 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
                     auto atom_j = neighbors[jj] & NEIGHMASK;
                     auto original_atom_j = original_atom_id_[atom_j];
-                    auto original_atom_j_mtt = original_atom_id_old_[atom_j];
-                    auto mtt_j_differs = (original_atom_j_mtt != original_atom_j);
                     auto j_is_original = (atom_j == original_atom_j);
 
-                    std::string msg = "[rank: " + std::to_string(comm->me) + "]";
-                    msg += " pair: " + std::to_string(atom_i) + " (original: " + std::to_string(original_atom_i) + " mtt: " + std::to_string(original_atom_i_mtt) + ") - " + std::to_string(atom_j) + " (original: " + std::to_string(original_atom_j) + " mtt: " + std::to_string(original_atom_j_mtt) + ")";
-
-                    std::string status = "";
-                    auto id_status = "";
-                    if (mtt_i_differs || mtt_j_differs) {
-                        id_status = "[MTT DIFFERS]";
-                    }
-
-                    msg += id_status;
-                    
                     if (!full_list && original_atom_i > original_atom_j) {
                         // Remove extra pairs if the model requested half-lists
-                        status = " (skipped by half-list condition)";
-                        msg += status;
-                        if (comm->me == 0 && print_nl) {
-                            std::cout << msg << std::endl;
-                        }
                         if (debug_nl) {
                             stats[1] += 1;
                         }
@@ -429,11 +329,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
 
                     if (!i_is_original && !j_is_original) {
                         // both atoms are periodic ghosts, skip the pair
-                        // status = " (skipped because both atoms are ghosts)";
-                        msg += status;  
-                        if (comm->me == 0 && print_nl) {
-                            std::cout << msg << std::endl;
-                        }
                         if (debug_nl) {
                             stats[2] += 1;
                         }
@@ -443,11 +338,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (!i_is_original && j_is_original) {
                         // this pair will be accounted for when we will process
                         // atom_j as the central atom
-                        status = " (skipped because atom_i is a ghost and atom_j is the original)";
-                        msg += status;
-                        if (comm->me == 0 && print_nl) {
-                            std::cout << msg << std::endl;
-                        }
                         if (debug_nl) {
                             stats[3] += 1;
                         }
@@ -468,17 +358,11 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                     if (distance2 > cutoff2) {
                         // LAMMPS neighbors list contains some pairs after the
                         // cutoff, we filter them here
-                        status = " (skipped by cutoff filter)";
-                        msg += status;
-                        if (comm->me == 0 && print_nl) {
-                            std::cout << msg << std::endl;
-                        }
                         if (debug_nl) {
                             stats[4] += 1;
                         }
                         continue;
                     }
-
 
                     // Compute the cell shift for the pair.
                     auto shift_i = std::array<double, 3>{
@@ -511,11 +395,6 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                             // shifts.
                             if (shift[0] + shift[1] + shift[2] < 0) {
                                 // drop shifts on the negative half-space
-                                status = " (skipped by negative half-space condition)";
-                                msg += status;
-                                if (comm->me == 0 && print_nl) {
-                                    std::cout << msg << std::endl;
-                                }
                                 if (debug_nl) {
                                     stats[5] += 1;
                                 }
@@ -538,24 +417,12 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
                                 //  X X X │ X X X
                                 //  X X X │ X X X
                                 //  X X X │ X X X
-
-                                status = " (skipped by negative half-plane condition)";
-                                msg += status;
-                                if (comm->me == 0 && print_nl) {
-                                    std::cout << msg << std::endl;
-                                }
                                 if (debug_nl) {
                                     stats[5] += 1;
                                 }
                                 continue;
                             }
                         }
-                    }
-
-                    status = " (kept)";
-                    msg += status;
-                    if (comm->me == 0 && print_nl) {
-                        std::cout << msg << std::endl;
                     }
 
                     if (debug_nl) {
@@ -705,38 +572,7 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
 
     cell.index_put_({torch::logical_not(pbc)}, torch::tensor({0.0}, tensor_options));
 
-    this->guess_periodic_ghosts_old();
     this->guess_periodic_ghosts();
-
-    {
-        static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
-        if (debug_nl) {
-            int n_map_minus1 = 0;
-            int n_atoms_original = 0;
-            for (int i = 0; i < atom->nlocal + atom->nghost; i++) {
-                int mapped = atom->map(atom->tag[i]);
-                if (mapped == -1) {
-                    n_map_minus1++;
-                    if (n_map_minus1 <= 5) {
-                        fprintf(stderr, "[rank %d] atom->map returned -1 for i=%d tag=%lld (ghost=%s)\n",
-                            comm->me, i, (long long)atom->tag[i], i >= atom->nlocal ? "yes" : "no");
-                    }
-                }
-                if (original_atom_id_[i] == i) n_atoms_original++;
-            }
-            fprintf(stderr, "\nmetatomic-cpu-map-debug [rank %d]: n_map_minus1=%d n_atoms_original=%d mta_to_lmp_size=%zu\n",
-                comm->me, n_map_minus1, n_atoms_original, mta_to_lmp.size());
-        }
-
-        if (debug_nl) {
-            int64_t checksum = 0;
-            for (int i = 0; i < atom->nlocal + atom->nghost; i++) {
-                checksum += (int64_t)original_atom_id_[i] * (i + 1);
-            }
-            fprintf(stderr, "\nmetatomic-cpu-map-debug [rank %d]: checksum=%lld\n",
-                comm->me, (long long)checksum);
-        }
-    }
 
     // Only keep the atoms which are not periodic images of other atoms
     auto mta_to_lmp_tensor = torch::from_blob(

--- a/src/ML-METATOMIC/metatomic_system.cpp
+++ b/src/ML-METATOMIC/metatomic_system.cpp
@@ -293,6 +293,7 @@ void MetatomicSystemAdaptor::setup_neighbors(metatomic_torch::System& system, Ne
             int64_t written = 0;
             int64_t sum_i = 0, sum_j = 0;
             int64_t n_i_original = 0, n_j_original = 0;
+            int64_t total_local = 0;
 
             // convert from LAMMPS neighbors list to metatomic format
             nl.samples.clear();
@@ -558,6 +559,18 @@ metatomic_torch::System MetatomicSystemAdaptor::system_from_lmp(
     cell.index_put_({torch::logical_not(pbc)}, torch::tensor({0.0}, tensor_options));
 
     this->guess_periodic_ghosts();
+
+    {
+        static bool debug_nl = (std::getenv("LAMMPS_METATOMIC_DEBUG_NL") != nullptr);
+        if (debug_nl) {
+            int n_atoms_original = 0;
+            for (size_t i = 0; i < original_atom_id_.size(); i++) {
+                if (original_atom_id_[i] == static_cast<int>(i)) n_atoms_original++;
+            }
+            fprintf(stderr, "metatomic-cpu-ghost-debug [rank %d]: total_atoms=%zu n_atoms_original=%d mta_to_lmp_size=%zu\n",
+                comm->me, original_atom_id_.size(), n_atoms_original, mta_to_lmp.size());
+        }
+    }
 
     // Only keep the atoms which are not periodic images of other atoms
     auto mta_to_lmp_tensor = torch::from_blob(

--- a/src/ML-METATOMIC/metatomic_system.h
+++ b/src/ML-METATOMIC/metatomic_system.h
@@ -99,7 +99,6 @@ public:
     // Some ghosts atoms correspond to periodic images of other atoms, we need
     // to identify them to avoid duplicated pairs in the neighbor lists.
     void guess_periodic_ghosts();
-    void guess_periodic_ghosts_old();
 
     /// Compute the inverse of the cell matrix of the system, accounting for
     /// non-periodic directions by setting the corresponding rows to an unit vector
@@ -123,11 +122,9 @@ public:
     // given atom tag if the ghost is a periodic image of another ghost; or the
     // id of the ghost in all other cases.
     std::vector<int> original_atom_id_;
-    std::vector<int> original_atom_id_old_;
     // Metatomic atom id for all atoms in the LAMMPS system.
     // Contains `atoms->nlocal + atoms->nghost` elements
     std::vector<int> lmp_to_mta_;
-    std::vector<int> lmp_to_mta_old_;
 
     // allocation cache holding the map from atom tag to atom id for local
     // atoms.

--- a/src/ML-METATOMIC/metatomic_system.h
+++ b/src/ML-METATOMIC/metatomic_system.h
@@ -99,6 +99,7 @@ public:
     // Some ghosts atoms correspond to periodic images of other atoms, we need
     // to identify them to avoid duplicated pairs in the neighbor lists.
     void guess_periodic_ghosts();
+    void guess_periodic_ghosts_old();
 
     /// Compute the inverse of the cell matrix of the system, accounting for
     /// non-periodic directions by setting the corresponding rows to an unit vector
@@ -122,9 +123,11 @@ public:
     // given atom tag if the ghost is a periodic image of another ghost; or the
     // id of the ghost in all other cases.
     std::vector<int> original_atom_id_;
+    std::vector<int> original_atom_id_old_;
     // Metatomic atom id for all atoms in the LAMMPS system.
     // Contains `atoms->nlocal + atoms->nghost` elements
     std::vector<int> lmp_to_mta_;
+    std::vector<int> lmp_to_mta_old_;
 
     // allocation cache holding the map from atom tag to atom id for local
     // atoms.


### PR DESCRIPTION
**Summary**

Reimplementing the `guess_periodic_ghosts` to account for non-deterministic behavior of the Kokkos neighborlist builds. 

In the non-kokkos version the NL is computed deterministically, with a certain set of rules that imply in what order the atoms land into the NL arrays. In kokkos, NLs are build chaotically by running multiple parallel threads, that yield an arbitrary order of neighbors in the NL. Somehow, the old implementation of `guess_periodic_ghosts` implicitly relied on that internal structure of the NL, that was only there in CPU runs and Kokkos runs with 1 MPI-task. 

Specifically, it appears that while executing the code to identify the `original_atom_ids` from the ghost atoms, we unintentionally obtained the closest periodic copy of each new ghost atom tag based on its distance from the current domain. This is because these atoms appeared in the NL earlier than more distant periodic copies. While it worked nicely on CPU, in the Kokkos version the NLs are build using parallel threads, and atoms land into the final NL in a random order, what led sometimes to distant ghost atoms entering the `original_atom_ids` just because they appeared earlier in the NL. This behavior later corrupted the check for atoms being original or not, and led to wrong NLs passed to a model. 

**Implementation Notes**

This PR reimplements the `guess_periodic_ghosts`. Now, instead of relying on the order of the atom in the NL, the _originality_ of an atom is defined based on a distance from the center of a current domain associated with a current MPI-task. The functionality was verified on both CPU and Kokkos versions and looks to yield consistent results with the old implementation (where it worked). 

---

**Additional fixes**
- Casted the initial guess for the NL cache in Kokkos to `uint64_t` due to an overflow in the case of the adaptive cutoff models
- Changed the access of the neighbors index from an iterator index `ii` to an actual atom index `atom_i`

---

**TODO**
- [x] Make sure the index change from `ii` to `atom_i` is properly accounted for in `guess_periodic_ghosts` 