### PR TITLE
Request uncertainty also for NC evaluations

### DIFF
--- a/src/ML-METATOMIC/pair_metatomic.cpp
+++ b/src/ML-METATOMIC/pair_metatomic.cpp
@@ -593,12 +593,11 @@ void PairMetatomic::compute(int eflag, int vflag) {
         } else {
             mta_data->energy_output->per_atom = false;
         }
-
         mta_data->evaluation_options->outputs.insert(mta_data->energy_key, mta_data->energy_output);
+    }
 
-        if (mta_data->uncertainty_output != nullptr) {
-            mta_data->evaluation_options->outputs.insert(mta_data->energy_uq_key, mta_data->uncertainty_output);
-        }
+    if (mta_data->uncertainty_output != nullptr) {
+        mta_data->evaluation_options->outputs.insert(mta_data->energy_uq_key, mta_data->uncertainty_output);
     }
 
     if (mta_data->non_conservative) {


### PR DESCRIPTION
The uncertainty wasn't being requested for NC evaluations, but then it was being accessed, leading to NC- and UQ-enabled models crashing in NC mode
