### PR TITLE
Exit cleanly when i-PI drops the connections rather than erroring out.

### DIFF
--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -27,6 +27,7 @@
 #include "kspace.h"
 #include "modify.h"
 #include "neighbor.h"
+#include "timer.h"
 #include "update.h"
 
 #include <cstring>
@@ -208,6 +209,7 @@ FixIPI::FixIPI(LAMMPS *lmp, int narg, char **arg) : Fix(lmp, narg, arg), irregul
     error->all(FLERR, "Invalid port for fix ipi: {}", port);
 
   hasdata = bsize = 0;
+  exit_flag = 0;
 
   // creates a temperature compute for all atoms
   modify->add_compute("IPI_TEMP all temp");
@@ -302,12 +304,12 @@ void FixIPI::initial_integrate(int /*vflag*/)
       else break;
     }
 
-    if (strcmp(header,"EXIT        ") == 0)
-      error->one(FLERR, "Got EXIT message from i-PI. Now leaving!");
-
-    // when i-PI signals it has positions to evaluate new forces,
-    // read positions and cell data
-    if (strcmp(header,"POSDATA     ") == 0)  {
+    // on EXIT, mark nat with a sentinel so all ranks can break out of
+    // the run loop cleanly (via timer->force_timeout) and let LAMMPS
+    // print the end-of-run timing summary.
+    if (strcmp(header,"EXIT        ") == 0) {
+      nat = -1;
+    } else if (strcmp(header,"POSDATA     ") == 0)  {
       readbuffer(ipisock, (char*) cellh, 9*8, error);
       readbuffer(ipisock, (char*) cellih, 9*8, error);
       readbuffer(ipisock, (char*) &nat, 4, error);
@@ -327,6 +329,16 @@ void FixIPI::initial_integrate(int /*vflag*/)
 
   // shares the atomic coordinates with everyone
   MPI_Bcast(&nat,1,MPI_INT,0,world);
+
+  // sentinel from the master EXIT branch above: trigger a clean run
+  // termination so Verlet's loop breaks out and Finish::end() prints
+  // the timing summary. exit_flag tells final_integrate to no-op.
+  if (nat == -1) {
+    timer->force_timeout();
+    exit_flag = 1;
+    return;
+  }
+
   // must also allocate the buffer on the non-head nodes
   if (bsize==0) {
     bsize=3*nat;
@@ -440,6 +452,14 @@ void FixIPI::final_integrate()
   double forceconv, potconv, posconv, pressconv, posconv3;
   char retstr[1024] = { '\0' };
 
+  // initial_integrate signalled an EXIT for this step. The intervening
+  // force compute already ran on stale positions; just skip the socket
+  // I/O so the run loop can break out at the next check_timeout.
+  if (exit_flag) {
+    hasdata = 0;
+    return;
+  }
+
   // conversions from LAMMPS units to atomic units, which are used by i-PI
   potconv=3.1668152e-06/force->boltz;
   posconv=0.52917721*force->angstrom;
@@ -491,6 +511,7 @@ void FixIPI::final_integrate()
     retstr[0] = '\0';
   }
 
+  int exit_now = 0;
   if (master) {
     // check for new messages
     while (true) {
@@ -501,10 +522,9 @@ void FixIPI::final_integrate()
       else break;
     }
 
-    if (strcmp(header,"EXIT        ") == 0)
-      error->one(FLERR, "Got EXIT message from i-PI. Now leaving!");
-
-    if (strcmp(header,"GETFORCE    ") == 0)  {
+    if (strcmp(header,"EXIT        ") == 0) {
+      exit_now = 1;
+    } else if (strcmp(header,"GETFORCE    ") == 0)  {
       // return force and energy data
       writebuffer(ipisock,"FORCEREADY  ",MSGLEN, error);
       writebuffer(ipisock,(char*) &pot,8, error);
@@ -517,6 +537,15 @@ void FixIPI::final_integrate()
     }
     else
       error->one(FLERR, "Wrapper did not ask for forces, I will now die!");
+  }
+
+  // propagate the EXIT decision so all ranks force_timeout together;
+  // the next Verlet iteration's check_timeout will then break the loop
+  // cleanly and let Finish::end() print the timing summary.
+  MPI_Bcast(&exit_now, 1, MPI_INT, 0, world);
+  if (exit_now) {
+    timer->force_timeout();
+    exit_flag = 1;
   }
 
   hasdata=0;

--- a/src/MISC/fix_ipi.cpp
+++ b/src/MISC/fix_ipi.cpp
@@ -304,9 +304,8 @@ void FixIPI::initial_integrate(int /*vflag*/)
       else break;
     }
 
-    // on EXIT, mark nat with a sentinel so all ranks can break out of
-    // the run loop cleanly (via timer->force_timeout) and let LAMMPS
-    // print the end-of-run timing summary.
+    // on EXIT set nat to -1 so all ranks can break out of
+    // the run loop cleanly (via timer->force_timeout)
     if (strcmp(header,"EXIT        ") == 0) {
       nat = -1;
     } else if (strcmp(header,"POSDATA     ") == 0)  {
@@ -330,9 +329,9 @@ void FixIPI::initial_integrate(int /*vflag*/)
   // shares the atomic coordinates with everyone
   MPI_Bcast(&nat,1,MPI_INT,0,world);
 
-  // sentinel from the master EXIT branch above: trigger a clean run
-  // termination so Verlet's loop breaks out and Finish::end() prints
-  // the timing summary. exit_flag tells final_integrate to no-op.
+  // trigger a clean run termination so the main loop breaks out and
+  // Finish::end() can be triggered. exit_flag is set so final_integrate
+  // no-ops.
   if (nat == -1) {
     timer->force_timeout();
     exit_flag = 1;
@@ -385,7 +384,7 @@ void FixIPI::initial_integrate(int /*vflag*/)
 
   // ensure atoms are in current box & update box via shrink-wrap
   // has to be be done before invoking Irregular::migrate_atoms()
-  //   since it requires atoms be inside simulation box
+  // since it requires atoms be inside simulation box
 
   // folds atomic coordinates close to the origin
   if (domain->triclinic) domain->x2lamda(atom->nlocal);
@@ -540,8 +539,7 @@ void FixIPI::final_integrate()
   }
 
   // propagate the EXIT decision so all ranks force_timeout together;
-  // the next Verlet iteration's check_timeout will then break the loop
-  // cleanly and let Finish::end() print the timing summary.
+  // the next Verlet iteration's check_timeout will then end the run cleanly
   MPI_Bcast(&exit_now, 1, MPI_INT, 0, world);
   if (exit_now) {
     timer->force_timeout();

--- a/src/MISC/fix_ipi.h
+++ b/src/MISC/fix_ipi.h
@@ -43,6 +43,7 @@ class FixIPI : public Fix {
   int kspace_flag;
   int reset_flag;
   int firsttime;
+  int exit_flag;
 
  private:
   class Irregular *irregular;


### PR DESCRIPTION
This prints the final stats, and is in general cleaner.

**Summary**

fix_ipi exits with an error when the server disconnects. this PR implements a cleaner exit mechanism, allowing among other things to print out the runtime stats that LAMMPS usually prints at the end of a simulation.

**Author(s)**

Michele Ceriotti, EPFL, michele.ceriotti@gmail.com

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Artificial Intelligence (AI) Tools Usage**

By submitting this pull request, I confirm that I did NOT use any AI tools to generate
all or parts of the code and modifications in this pull request.

**Backward Compatibility**

This should be fully backward compatible.

**Implementation Notes**

This simply sets a flag when the socket drops the connection, which is picked up at the end of the verlet steps to trigger the usual LAMMPS exit path.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [x] The feature has been verified to work with the conventional build system
- [x] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

